### PR TITLE
Speedup route search algorithm in RouteChoice class by ~60x

### DIFF
--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -992,12 +992,17 @@ class RouteChoice:
         s.dist, s.pred = dijkstra(csgraph=csr_mat, directed=True, indices=None, return_predecessors=True)
 
         # Directly use the predecessors to update the next matrix for route choice
+        # Vectorized update of s.next
         n_vertices = s.pred.shape[0]
         s.next = np.full((n_vertices, n_vertices), -1, dtype=int)  # Initialize with -1
-        for i in range(n_vertices):
-            for j in range(n_vertices):
-                if i != j and s.pred[i, j] != -9999:
-                    s.next[i, j] = s.pred[i, j]
+
+        # Vectorized operation to copy `s.pred` into `s.next` where pred != -9999
+        valid_pred = s.pred != -9999
+        s.next[valid_pred] = s.pred[valid_pred]
+
+        # Correcting diagonal elements if necessary
+        # This step ensures that diagonal elements, which represent paths from a node to itself, are correctly set to -1.
+        np.fill_diagonal(s.next, -1)
 
     def route_search_all_old(s, infty=9999999999999999999, noise=0):
         """


### PR DESCRIPTION
This pull request introduces a significant optimization to the `RouteChoice` class's `route_search_all` method. By shifting from the Floyd-Warshall algorithm to Dijkstra's algorithm and employing vectorized operations for matrix updates, performance is sped up by ~60x for a medium sized graph. These changes are particularly effective for sparse graphs, which are common in road network simulations.

### Changes
1. **Algorithm update** (1b9df13): Replaced the Floyd-Warshall algorithm with Dijkstra's algorithm using `scipy.sparse.csgraph.dijkstra`. This change leverages the sparsity of the road network graphs, reducing computational complexity from \(O(V^3)\) to \(O((V + E) \log V)\), where \(V\) is the number of vertices and \(E\) is the number of edges.
2. **Vectorization of matrix updates** (e93a4ab): Replaced nested loops for updating the `next` matrix with NumPy's vectorized operations and boolean indexing. This optimization reduces the overhead associated with Python loops and utilizes efficient low-level operations for array manipulations (this was originally a very slow part of the graph).

### Performance Implications
In a benchmark involving a real-world road graph with 3275 links and 1552 nodes, the execution time of `route_search_all` was reduced from approximately 19 seconds to just about 0.3 seconds. This demonstrates the significant efficiency gains achieved through these optimizations.

If route search will be a bottleneck in the future again, it might be worth investigating the potential for leveraging C-optimized libraries like `graph-tool` or `igraph` for even more performance.

If merged, this PR closes #53.