### PR TITLE
Add release.yml file for automatic release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,34 @@
+# Docs: https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes
+changelog:
+  exclude:
+    labels:
+      - ignore-for-release
+  categories:
+    - title: ⚠️ Breaking changes
+      labels:
+        - breaking
+    - title: 🧪 Experimental features
+      labels:
+        - experimental
+    - title: 🎉 New features added
+      labels:
+        - feature
+    - title: 🛠 Enhancements made
+      labels:
+        - enhancement
+    - title: 🐛 Bugs fixed
+      labels:
+        - bug
+    - title: 📜 Documentation improvements
+      labels:
+        - docs
+    - title: 🔧 Maintenance
+      labels:
+        - ci
+        - testing
+        - dependency
+        - maintenance
+        - packaging
+    - title: Other changes
+      labels:
+        - "*"


### PR DESCRIPTION
This PR adds a configuration file `.github/release.yml` that lets GitHub automatically draft release notes based on the labels attached to PRs that will be included in that release. These drafted release notes can form a consistent basis for our changelog and manually expanded with context for certain PRs if needed.

The currently proposed labels are `breaking`, `experimental`, `feature`, `enhancement`, `bug`, `docs`, `ci`, `testing`, `dependency`, `maintenance` and `packaging`. The last four are grouped in the changelog under _Maintenance 🔧_.

For this to work nicely, it's important that all merged PRs have one of these labels attached to them and that the PR titles are sufficiently descriptive.

As an example, we use this over at Mesa to create pretty release notes:
- All our merged PRs [are labeled](https://github.com/projectmesa/mesa/pulls?q=is%3Apr+is%3Amerged) with one of the labels listed in `release.yml` (and have a clear, descriptive title).
- A release can now look [like this](https://github.com/projectmesa/mesa/releases/tag/v2.3.0).
- The "What's Changed" part is fully automated generated by pressing the "Generate release notes" button when creating a new release.
   ![image](https://github.com/user-attachments/assets/86d0f331-7138-4182-a633-f8a00e7ce88e)

For further reference, see [Automatically generated release notes](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes).