### PR TITLE
Analyzer: Add time-filtering functionality

### DIFF
--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -272,7 +272,7 @@ class Node:
                 inlink = veh.link
 
                 #累積台数関連更新
-                inlink.cum_arrival[-1][1] += s.W.DELTAN
+                inlink.cum_departure[-1][1] += s.W.DELTAN
                 outlink.cum_arrival[-1][1] += s.W.DELTAN
                 inlink.traveltime_actual[int(veh.link_arrival_time/s.W.DELTAT):] = s.W.T*s.W.DELTAT - veh.link_arrival_time #自分の流入時刻より後の実旅行時間も今の実旅行時間で仮決め．後に流出した車両が上書きする前提
 


### PR DESCRIPTION
_This PR is meant as a proof-of-concept and is not necessarily production quality. It builds on both #119 and #121, only 5ace21f811df27adaf1ba403d97215d05e6cd1a7 contains new functionality compared to #121._

This PR introduces a new time-filtering functionality for analyzing link and vehicle data over a specified time window (`t_seconds`). This allows for more granular, time-sensitive analysis, which is particularly useful when evaluating the most recent simulation behavior.

### Key changes:
1. **Time-based filtering for data export**:
   - Added an optional `t_seconds` parameter to several data export functions (`link_to_pandas`, `vehicles_to_pandas`, etc.), enabling filtering of data from the last `t_seconds` of simulation time.
   - This functionality is applied across link-level, vehicle-level, and area-based analyses, ensuring consistency in time-filtered outputs.

2. **Updates to cumulative tracking in `Link` objects**:
   - Modified how cumulative vehicle arrivals and departures are tracked. Each time step now records both the current time and cumulative count, allowing time-based filtering to function properly.

3. **Enhancements to data structure for link travel times**:
   - The `link_to_pandas` function now includes a `t` column, recording the simulation time for each data point. This is used to apply time-based filtering for link statistics like traffic volume, remaining vehicles, and travel times.
   - Similarly, `vehicles_to_pandas` includes time filtering, ensuring vehicle logs reflect only recent events.

4. **Cumulative arrival and departure handling**:
   - Adjustments were made to ensure cumulative vehicle arrivals and departures are correctly updated across multiple time steps and used in conjunction with the new filtering functionality.

These changes improve the flexibility of the analysis tools, allowing users to inspect the most recent simulation data without manually post-processing large datasets. The changes also maintain backwards compatibility by default, only applying time filters if the `t_seconds` parameter is specified.

Known bugs:
- The total_travel_time is currently negative, starting around 0 and getting increasingly negative
- The average_speed, as added in #121, starts now negative, and increases, in some cases it converges towards 0.

More validation of other numbers is needed, but other variables generally look good.

Part of #120.