### PR TITLE
Analyzer: Add time-filtering functionality

### DIFF
--- a/uxsim/analyzer.py
+++ b/uxsim/analyzer.py
@@ -1218,7 +1218,7 @@ class Analyzer:
         if s.W.vehicle_logging_timestep_interval != 1:
             warnings.warn("vehicle_logging_timestep_interval is not 1. The output data is not exactly accurate.", LoggingWarning)
 
-        if s.flag_pandas_convert == 0:
+        if s.flag_pandas_convert == 0 or t_seconds is not None:
             out = [["name", "dn", "orig", "dest", "t", "link", "x", "s", "v"]]
             current_time = s.W.T * s.W.DELTAT
             for veh in s.W.VEHICLES.values():


### PR DESCRIPTION
This PR introduces a new time-filtering functionality for analyzing link and vehicle data over a specified time window (`t_seconds`). This allows for more granular, time-sensitive analysis, which is particularly useful when evaluating the most recent simulation behavior. It basically allows inputting `t_seconds` into `vehicles_to_pandas`, `link_to_pandas` and `area_to_pandas`, which makes it collect the last `t_seconds` of simulation time.

It's a clean implementation of PR #123 and is part of issue #120.

A few things to note:

- The `t_seconds` API is maybe still not ideal. Maybe you want to either:
  - Input `t_start` and `t_end`, and collect between that period.
  - Input a binwidth `t_bin`, and then slice up the data in equal parts of that width.
- It only touches the Analyzer class, so in theory can now be run at the end of a simulation instead of during it. For that the API above might make more sense.

Things to review:

- I think I'm triggering this at t=900 simulation time, but for some reason it takes t=930. Maybe the index is wrong by 1 or something like that
- I had to add the `or t_seconds is not None` to the `if s.flag_pandas_convert == 0 or t_seconds is not None:` check in `vehicles_to_pandas`. Might be more elegant ways to solve it.

This branch can be installed with:
```
pip install -U -e git+https://github.com/EwoutH/uxsim@pandas_time_filter#egg=uxsim
```