### PR TITLE
Analyzer: Add time_bin argument to area_to_pandas

### DIFF
--- a/uxsim/analyzer.py
+++ b/uxsim/analyzer.py
@@ -3,6 +3,7 @@ Analyzer for a UXsim simulation result.
 This module is automatically loaded when you import the `uxsim` module.
 """
 
+import math
 import numpy as np
 import matplotlib.pyplot as plt
 import glob, os, csv, time
@@ -1672,11 +1673,11 @@ class Analyzer:
             s.df_linkc = pd.DataFrame(out[1:], columns=out[0])
         else:
             out = []
-            num_bins = s.W.TIME // time_bin
+            num_bins = math.ceil(s.W.TIME / time_bin)  # Use ceiling division
             for l in s.W.LINKS:
                 for bin_idx in range(num_bins):
                     t_start = bin_idx * time_bin
-                    t_end = (bin_idx + 1) * time_bin
+                    t_end = min((bin_idx + 1) * time_bin, s.W.TIME)  # Ensure last bin doesn't exceed simulation time
                     idx_start = int(t_start / s.W.DELTAT)
                     idx_end = int(t_end / s.W.DELTAT)
 

--- a/uxsim/analyzer.py
+++ b/uxsim/analyzer.py
@@ -1477,8 +1477,15 @@ class Analyzer:
 
             area_data = df_slice.loc[rows]
 
+            # Count vehicles entering the area
+            entering_links = area_data[~area_data["start_node"].isin(area_set) & area_data["end_node"].isin(area_set)]
+            # Count vehicles starting their trip within the area
+            internal_start_links = area_data[
+                area_data["start_node"].isin(area_set) & ~area_data["end_node"].isin(area_set)]
+
+            traffic_volume = entering_links["traffic_volume"].sum() + internal_start_links["traffic_volume"].sum()
+
             n_links = area_data["link"].nunique()
-            traffic_volume = area_data["traffic_volume"].sum()
             vehicles_remain = area_data["vehicles_remain"].sum()
             total_travel_time = (area_data["average_travel_time"] * area_data["traffic_volume"]).sum()
             total_free_time = (area_data["free_travel_time"] * area_data["traffic_volume"]).sum()

--- a/uxsim/analyzer.py
+++ b/uxsim/analyzer.py
@@ -1438,7 +1438,7 @@ class Analyzer:
         s.df_areas2areas = pd.DataFrame(out[1:], columns=out[0])
         return s.df_areas2areas
 
-    def area_to_pandas(s, areas, area_names=None, border_include=True, time_bin=None):
+    def area_to_pandas(s, areas, area_names=None, border_include=True, time_bin=None, set_index=False):
         """
         Compute traffic stats in area and return as pandas.DataFrame.
 
@@ -1452,6 +1452,8 @@ class Analyzer:
             If set to True, the links on the border of the area are included in the analysis. Default is True.
         time_bin : int, optional
             The time bin size in seconds. If provided, results will be aggregated by time bins.
+        set_index : bool, optional
+            If set to True, the DataFrame index will be set to the area, and (area, time_bin) if time_bin is not None. Default is False.
 
         Returns
         -------
@@ -1508,17 +1510,18 @@ class Analyzer:
                 for _, group in df_links.groupby("time_bin"):
                     area_result = process_area(area_set, group)
                     result.append({"area": area_name, "time_bin": group["time_bin"].iloc[0], **area_result})
-
-            s.df_area = pd.DataFrame(result).set_index(["time_bin", "area"])
         else:
             result = []
             for area_set, area_name in zip(areas_set, area_names):
                 area_result = process_area(area_set, df_links)
                 result.append({"area": area_name, **area_result})
 
-            s.df_area = pd.DataFrame(result).set_index("area")
-
-        return s.df_area
+        s.df_area = pd.DataFrame(result)
+        if set_index:
+            if time_bin is not None:
+                return s.df_area.set_index(["time_bin", "area"])
+            else:
+                return s.df_area.set_index(["area"])
 
     def vehicle_groups_to_pandas(s, groups, group_names=None):
         """

--- a/uxsim/analyzer.py
+++ b/uxsim/analyzer.py
@@ -1519,9 +1519,10 @@ class Analyzer:
         s.df_area = pd.DataFrame(result)
         if set_index:
             if time_bin is not None:
-                return s.df_area.set_index(["time_bin", "area"])
+                s.df_area.set_index(["time_bin", "area"], inplace=True)
             else:
-                return s.df_area.set_index(["area"])
+                s.df_area.set_index(["area"], inplace=True)
+        return s.df_area
 
     def vehicle_groups_to_pandas(s, groups, group_names=None):
         """


### PR DESCRIPTION
This PR introduces time-binned analysis capabilities to the `link_to_pandas` and `area_to_pandas` methods in the Analyzer class, while also addressing an issue with traffic volume calculation. These changes allow for more flexible, granular, and accurate analysis of traffic data over time.

### Changes
1. Added `time_bin` argument to `link_to_pandas`:
   - When `time_bin` is None, the method behaves as before.
   - When `time_bin` is specified, data is aggregated into time bins.
   - Performance is improved for time-binned analysis due to reduced iterations.

2. Updated `area_to_pandas` to work with time-binned data:
   - Now uses the time-binned data from `link_to_pandas` when `time_bin` is specified.
   - Calculates area statistics for each time bin.

3. Fixed traffic volume calculation in `area_to_pandas`:
   - Now correctly counts vehicles entering the area from outside.
   - Also counts vehicles starting their trip within the area.
   - Avoids double-counting vehicles passing through multiple links within the area.

4. Data validation:
   - `traffic_volume` now represents the volume per bin instead of cumulative.
   - `total_travel_time` is calculated per bin, which is more logical for a binned approach.

### Notes
- The test suite has been updated to reflect the changes in traffic volume calculation.
- The new approach provides a more accurate representation of traffic patterns over time.

Part of #120.

**TODO**
- [x] Validate data
- [x] Add argument to `link_to_pandas`
- [x] Fix traffic volume calculation