### PR TITLE
UXsim: Add new get_all_distances method to RouteChoice

### DIFF
--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -1374,6 +1374,28 @@ class RouteChoice:
         s.dist = dist.T
         s.next = pred.T
 
+    def get_all_distances(self, directed=True):
+        """
+        Compute the shortest distances (in meters) between all node pairs based on link lengths.
+
+        Returns
+        -------
+        distances : np.ndarray
+            A matrix where distances[i, j] contains the shortest distance between node i and node j.
+        """
+        num_nodes = len(self.W.NODES)
+        distances = np.full((num_nodes, num_nodes), np.inf)  # Initialize with infinity
+
+        # Fill in the distances based on the link lengths
+        for link in self.W.LINKS:
+            i = link.start_node.id
+            j = link.end_node.id
+            distances[i, j] = min(distances[i, j], link.length)
+
+        # Use Dijkstra algorithm to compute shortest distances
+        distances = *dijkstra(csr_matrix(distances), directed=directed, return_predecessors=False),
+        return distances
+
     def homogeneous_DUO_update(s):
         """
         Update link preference of all homogeneous travelers based on DUO principle.


### PR DESCRIPTION
`get_all_distances` is a new helper method that returns distance array in the same format as `s.dist`. This way you can look up distances the same way as you look up travel time.

Usage:
```Python
distance_array = w.ROUTECHOICE.get_all_distances()

some_distance = distance_array[o_node.id][d_node.id]
some_travel_time = uw.ROUTECHOICE.dist[o_node.id][d_node.id]
```
One consideration could be saving this matrix internally in the `RouteChoice` class, instead of returning it.

This PR was validated that it outputs the same distances as NetworkX.