### PR TITLE
Specify dtypes for NumPy arrays

### DIFF
--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -1403,7 +1403,7 @@ class RouteChoice:
         end_nodes = np.array([l.end_node.id for l in s.W.LINKS], dtype=np.uint16)
 
         # Create the next_node_mask
-        next_node_mask = np.zeros((num_nodes, num_links), dtype=np.bool)
+        next_node_mask = np.zeros((num_nodes, num_links), dtype=np.bool_)
         for k in range(num_nodes):
             next_node_mask[k] = end_nodes == s.next[start_nodes, k]
 
@@ -1880,7 +1880,7 @@ class World:
 
         #generate adjacency matrix
         W.ROUTECHOICE = RouteChoice(W)
-        W.ADJ_MAT = np.zeros([len(W.NODES), len(W.NODES)], dtype=np.bool)
+        W.ADJ_MAT = np.zeros([len(W.NODES), len(W.NODES)], dtype=np.bool_)
         W.ADJ_MAT_LINKS = dict() #リンクオブジェクトが入った隣接行列（的な辞書）
         for link in W.LINKS:
             for i,node in enumerate(W.NODES):

--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -1403,7 +1403,7 @@ class RouteChoice:
         end_nodes = np.array([l.end_node.id for l in s.W.LINKS], dtype=np.uint16)
 
         # Create the next_node_mask
-        next_node_mask = np.zeros((num_nodes, num_links), dtype=bool)
+        next_node_mask = np.zeros((num_nodes, num_links), dtype=np.bool)
         for k in range(num_nodes):
             next_node_mask[k] = end_nodes == s.next[start_nodes, k]
 
@@ -1880,7 +1880,7 @@ class World:
 
         #generate adjacency matrix
         W.ROUTECHOICE = RouteChoice(W)
-        W.ADJ_MAT = np.zeros([len(W.NODES), len(W.NODES)], dtype=bool)
+        W.ADJ_MAT = np.zeros([len(W.NODES), len(W.NODES)], dtype=np.bool)
         W.ADJ_MAT_LINKS = dict() #リンクオブジェクトが入った隣接行列（的な辞書）
         for link in W.LINKS:
             for i,node in enumerate(W.NODES):


### PR DESCRIPTION
The default dtype in NumPy is float64, or a 64-bit floating point number. These are very large and not that fast in calculations.

In this commit a dtype is defined for every array, with a fitting type and precision. Often float32 is used, which is the fastest in calculations (fully hardware accelerated, often 2x faster than float64) and has only half the memory footprint of float64. Sometimes an even faster int or uint (for counts) or bool (for masks) is used. Contrary to floats, smaller ints are faster than the larger ints, so often int16 (which covers -32768 to 32767) or uint16 (0 to 65535) is often enough for counters.

After #144, this further reduced memory usage from 471 MB to 407 MB.

See for reference: https://numpy.org/doc/stable/user/basics.types.html

Part of: https://github.com/toruseo/UXsim/issues/143.