### PR TITLE
RouteChoice: optimize memory usage by in-place updates to `route_pref`

### DIFF
--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -1408,9 +1408,11 @@ class RouteChoice:
             next_node_mask[k] = end_nodes == s.next[start_nodes, k]
 
         # Update route preferences
-        s.route_pref = np.where(next_node_mask,
-                                (1 - weights[:, np.newaxis]) * s.route_pref + weights[:, np.newaxis],
-                                (1 - weights[:, np.newaxis]) * s.route_pref)
+        # In-place scaling of all elements
+        s.route_pref *= (1 - weights[:, np.newaxis])
+
+        # In-place addition of weights where next_node_mask is True
+        s.route_pref += weights[:, np.newaxis] * next_node_mask
 
 
 class World:


### PR DESCRIPTION
This commit optimizes memory usage in the `homogeneous_DUO_update` method by implementing in-place scaling and addition for `s.route_pref`. This change eliminates the creation of new arrays, addressing potential memory leaks during repeated updates, particularly in long-running simulations.

This commit doesn't solve the memory leak, I suspect it's still present somewhere. But it reduces the memory usage from 1189 MB to 647 MB in a large-scale simulation test.

Part of https://github.com/toruseo/UXsim/issues/143.