### PR TITLE
Remove dead Vehicle::build_full_log and build_full_log_np (-107 lines)

### DIFF
--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -704,31 +704,6 @@ NB_MODULE(uxsim_cpp, m) {
              "Departure time in seconds")
         .def_rw("route_choice_principle", &Vehicle::route_choice_principle)
         .def_rw("route_choice_uncertainty", &Vehicle::route_choice_uncertainty)
-        .def("build_full_log_np", [](const Vehicle &v) -> nb::dict {
-                 // Per-vehicle numpy version: all data as numpy/int, no strings.
-                 // Zero-copy via vector ownership transfer.
-                 auto fl = v.build_full_log();
-                 size_t m = fl.log_t_link.size();
-                 nb::dict d;
-                 d["log_t"] = make_numpy_move(std::move(fl.log_t));
-                 d["log_x"] = make_numpy_move(std::move(fl.log_x));
-                 d["log_v"] = make_numpy_move(std::move(fl.log_v));
-                 d["log_s"] = make_numpy_move(std::move(fl.log_s));
-                 d["log_lane"] = make_numpy_move(std::move(fl.log_lane));
-                 d["log_link"] = make_numpy_move(std::move(fl.log_link));
-                 d["log_state"] = make_numpy_move(std::move(fl.log_state));
-                 // log_t_link as two parallel numpy arrays
-                 std::vector<double> ltl_t(m);
-                 std::vector<int> ltl_id(m);
-                 for (size_t i = 0; i < m; i++) {
-                     ltl_t[i] = fl.log_t_link[i].first;
-                     ltl_id[i] = fl.log_t_link[i].second;
-                 }
-                 d["log_t_link_t"] = make_numpy_move(std::move(ltl_t));
-                 d["log_t_link_id"] = make_numpy_move(std::move(ltl_id));
-                 return d;
-             },
-             "Build full log arrays as numpy arrays, all int (no string conversion)")
         ;
 
     m.def("get_compile_datetime", &get_compile_datetime, "Return the compile date and time");

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -1006,70 +1006,7 @@ double Vehicle::departure_time_in_second() const {
 }
 
 
-/**
- * @brief Build full log arrays with home-timestep prepend.
- * Prepends missing "home" timesteps so indices match Python convention
- * (Python records from T=0 every timestep; C++ starts at departure_time).
- */
-Vehicle::FullLog Vehicle::build_full_log() const {
-    FullLog fl;
 
-    int n_missing = 0;
-    if (log_size > 0 && log_t[0] > 0) {
-        n_missing = static_cast<int>(log_t[0] / w->delta_t);
-    }
-
-    size_t total = n_missing + log_size;
-    fl.log_t.reserve(total);
-    fl.log_x.reserve(total);
-    fl.log_v.reserve(total);
-    fl.log_state.reserve(total);
-    fl.log_s.reserve(total);
-    fl.log_lane.reserve(total);
-    fl.log_link.reserve(total);
-
-    // Prepend home entries
-    for (int i = 0; i < n_missing; i++) {
-        fl.log_t.push_back(i * w->delta_t);
-        fl.log_x.push_back(-1);
-        fl.log_v.push_back(-1);
-        fl.log_state.push_back(vsHOME);
-        fl.log_s.push_back(-1);
-        fl.log_lane.push_back(-1);
-        fl.log_link.push_back(-1);
-    }
-
-    // Append C++ log entries with state-based adjustments
-    for (size_t i = 0; i < log_size; i++) {
-        fl.log_t.push_back(log_t[i]);
-
-        int st = log_state[i];
-        fl.log_state.push_back(st);
-
-        bool is_run = (st == vsRUN);
-        fl.log_x.push_back(is_run ? log_x[i] : -1);
-        fl.log_v.push_back(is_run ? log_v[i] : -1);
-        fl.log_s.push_back(is_run ? 0 : -1);
-        fl.log_lane.push_back(log_lane[i]);
-        fl.log_link.push_back(log_link[i]);
-    }
-
-    // Build log_t_link from the full (prepended) log arrays — all ints, no strings
-    fl.log_t_link.emplace_back(departure_time, LOG_T_LINK_HOME);
-    int prev_link_id = -999;
-    for (size_t i = 0; i < fl.log_link.size(); i++) {
-        int lid = fl.log_link[i];
-        if (lid >= 0 && lid != prev_link_id) {
-            fl.log_t_link.emplace_back(fl.log_t[i], lid);
-            prev_link_id = lid;
-        }
-    }
-    if (state == vsEND) {
-        fl.log_t_link.emplace_back((arrival_time >= 0) ? arrival_time : -1.0, LOG_T_LINK_END);
-    }
-
-    return fl;
-}
 
 
 // -----------------------------------------------------------------------

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -251,24 +251,9 @@ struct Vehicle {
     // Helper: return departure_time in seconds (already in seconds in C++)
     double departure_time_in_second() const;
 
-    // Helper: build full log arrays with home-timestep prepend.
-    // All data is int/double — no string allocation for maximum speed.
-    // String conversion is done at the binding layer only when needed.
-    struct FullLog {
-        std::vector<double> log_t;
-        std::vector<double> log_x;
-        std::vector<double> log_v;
-        std::vector<int> log_state;     // int: 0=home,1=wait,2=run,3=end,4=abort
-        std::vector<double> log_s;
-        std::vector<int> log_lane;
-        std::vector<int> log_link;      // link ID, -1 for home/none
-        // log_t_link: (time, link_id) pairs for link transitions.
-        // Special IDs: -1 = "home", -2 = "end"
-        std::vector<std::pair<double, int>> log_t_link;
-    };
+    // Special link IDs for log_t_link entries
     static constexpr int LOG_T_LINK_HOME = -1;
     static constexpr int LOG_T_LINK_END  = -2;
-    FullLog build_full_log() const;
 
 };
 

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -501,9 +501,6 @@ class CppVehicle:
             return
         # Batch-fetch all vehicle raw logs at once
         self.W._build_all_vehicle_log_caches()
-        # If batch didn't populate us (shouldn't happen), fallback to individual
-        if self._log_cache is None:
-            self._log_cache = self._cpp_vehicle.build_full_log_np()
 
     @property
     def log_t(self):


### PR DESCRIPTION
## Summary
Remove `Vehicle::build_full_log()` and its `build_full_log_np` binding, which were dead code.

## Why dead

The call chain was:
1. `veh.log_t` (public API) → `_ensure_log_raw()` → `W._build_all_vehicle_log_caches()` (batch API)
2. If batch didn't populate the cache → fallback to `_cpp_vehicle.build_full_log_np()` (per-vehicle)

But the batch API (`build_all_vehicle_logs_flat_compact`) always populates all vehicle caches, so the fallback at step 2 was **never reached**.

## Removed (-107 lines)

| File | What | Lines |
|------|------|-------|
| traffi.cpp | `Vehicle::build_full_log()` implementation | -63 |
| traffi.h | `FullLog` struct definition | -14 |
| bindings.cpp | `build_full_log_np` binding lambda | -27 |
| uxsim_cpp_wrapper.py | `_ensure_log_raw` fallback to `build_full_log_np` | -3 |

Kept `LOG_T_LINK_HOME`/`LOG_T_LINK_END` constants (used by `build_all_vehicle_logs_flat_compact`).

## Test plan
- [x] All 190 test_cpp_mode.py tests pass (`--reruns 5`)
- [x] All 8 test_cpp_build.py tests pass

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)