### PR TITLE
Fix C++ DTA solver inconsistencies with Python solvers

### DIFF
--- a/demos_and_examples/example_28en_benchmark_cpp_mode.py
+++ b/demos_and_examples/example_28en_benchmark_cpp_mode.py
@@ -195,7 +195,7 @@ def run_due_dso(seed, cpp):
     results["_duo_link_df"] = W.analyzer.link_to_pandas()
 
     # DUE
-    solver_DUE = SolverDUE(create_world)
+    solver_DUE = SolverDUE(create_world, cpp=cpp)
     t0 = time.perf_counter()
     solver_DUE.solve(max_iter=100)
     elapsed_due = time.perf_counter() - t0
@@ -205,7 +205,7 @@ def run_due_dso(seed, cpp):
     results["_due_link_df"] = _avg_last_n_link_dfs(solver_DUE.dfs_link, n=20)
 
     # DSO
-    solver_DSO = SolverDSO_D2D(create_world)
+    solver_DSO = SolverDSO_D2D(create_world, cpp=cpp)
     t0 = time.perf_counter()
     solver_DSO.solve(max_iter=100)
     elapsed_dso = time.perf_counter() - t0

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8046,6 +8046,50 @@ def test_dta_solver_due_grid_cpp_vs_python():
     assert ttt_cpp == pytest.approx(ttt_py, rel=0.2)
 
 
+def test_dta_solver_dso_intermid_solution_is_best_cpp():
+    """CppSolverDSO_D2D keeps the best-TTT iteration's World as W_sol (like Python)."""
+    from uxsim.DTAsolvers import SolverDSO_D2D
+
+    # High swap_prob makes TTT oscillate so the best iteration is not the last one
+    solver = SolverDSO_D2D(lambda: _create_dta_grid_world(seed=0, cpp=True), cpp=True)
+    solver.solve(max_iter=5, swap_prob=0.9, print_progress=False)
+    best_idx = int(np.argmin(solver.ttts))
+    assert solver.W_sol.analyzer.total_travel_time == pytest.approx(solver.ttts[best_idx], abs=1)
+
+
+def test_dta_solver_cost_log_unfinished_vehicles_cpp():
+    """cost_log entries match Python's ts[-1] - ts[0] definition, incl. unfinished vehicles."""
+    from uxsim.DTAsolvers import SolverDUE
+
+    def create_World():
+        W = uxsim.World(name="", deltan=5, tmax=1500, duo_update_time=300,
+                        print_mode=0, save_mode=0, show_mode=0, random_seed=0, cpp=True)
+        W.addNode("orig1", 0, 0)
+        W.addNode("orig2", 0, 2)
+        W.addNode("merge", 1, 1)
+        W.addNode("dest", 2, 1)
+        W.addLink("link1", "orig1", "merge", length=1000, free_flow_speed=20)
+        W.addLink("link2", "orig2", "merge", length=1000, free_flow_speed=20)
+        W.addLink("link3", "merge", "dest", length=1000, free_flow_speed=20)
+        W.adddemand("orig1", "dest", 0, 1400, 0.5)
+        W.adddemand("orig2", "dest", 0, 1400, 0.6)
+        return W
+
+    with pytest.warns(UserWarning):
+        solver = SolverDUE(create_World, cpp=True)
+        solver.solve(max_iter=2, print_progress=False)
+
+    W = solver.W_sol
+    n_unfinished = 0
+    for key, veh in W.VEHICLES.items():
+        r, ts = veh.traveled_route()
+        expected = ts[-1] - ts[0] if len(ts) else 0
+        assert solver.cost_log[-1][key] == pytest.approx(expected)
+        if veh.state != "end":
+            n_unfinished += 1
+    assert n_unfinished > 0  # scenario must actually contain unfinished trips
+
+
 def test_dta_solver_dfs_link_per_iteration_cpp():
     """C++ solvers record dfs_link every iteration (like Python solvers)."""
     from uxsim.DTAsolvers import SolverDUE, SolverDSO_D2D

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8046,6 +8046,22 @@ def test_dta_solver_due_grid_cpp_vs_python():
     assert ttt_cpp == pytest.approx(ttt_py, rel=0.2)
 
 
+def test_dta_solver_dfs_link_per_iteration_cpp():
+    """C++ solvers record dfs_link every iteration (like Python solvers)."""
+    from uxsim.DTAsolvers import SolverDUE, SolverDSO_D2D
+
+    max_iter = 3
+    for solver_class in [SolverDUE, SolverDSO_D2D]:
+        solver = solver_class(lambda: _create_dta_grid_world(seed=42, cpp=True), cpp=True)
+        solver.solve(max_iter=max_iter, print_progress=False)
+        assert len(solver.dfs_link) == max_iter
+        for df in solver.dfs_link:
+            assert len(df) == len(solver.W_sol.LINKS)
+            assert df["traffic_volume"].sum() > 0
+            # links with traffic must have valid travel time stats
+            assert (df["delay_ratio"][df["traffic_volume"] > 0] > 0).all()
+
+
 @pytest.mark.flaky(reruns=5)
 def test_dta_solver_dso_d2d_grid_cpp_vs_python():
     """SolverDSO_D2D on 9x9 grid: C++ and Python produce similar TTT."""

--- a/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
+++ b/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
@@ -344,8 +344,8 @@ class CppSolverDUE(SolverDUE):
 
             W.dict_od_to_routes = dict_od_to_routes
             s.W_intermid_solution = W
-            if is_last_iter:
-                s.dfs_link.append(W.analyzer.link_to_pandas())
+
+            s.dfs_link.append(W.analyzer.link_to_pandas())
 
             rng_seed = random.randint(0, 2**31 - 1)
             cpp_result = W._cpp_world.route_swap_due(
@@ -474,8 +474,7 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
                 elif W.analyzer.average_travel_time < s.W_intermid_solution.analyzer.average_travel_time:
                     s.W_intermid_solution = W
 
-            if is_last_iter:
-                s.dfs_link.append(W.analyzer.link_to_pandas())
+            s.dfs_link.append(W.analyzer.link_to_pandas())
 
             rng_seed = random.randint(0, 2**31 - 1)
             cpp_swap_num = swap_num if swap_num is not None else -1

--- a/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
+++ b/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
@@ -275,10 +275,6 @@ class CppSolverDUE(SolverDUE):
         if print_progress:
             W_orig.print_scenario_stats()
 
-        dict_od_to_vehid = defaultdict(lambda: [])
-        for key, veh in W_orig.VEHICLES.items():
-            dict_od_to_vehid[veh.orig.name, veh.dest.name].append(key)
-
         if W_orig.finalized == False:
             W_orig.finalize_scenario()
 
@@ -401,10 +397,6 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
         _ensure_cpp_world(W_orig, "CppSolverDSO_D2D")
         if print_progress:
             W_orig.print_scenario_stats()
-
-        dict_od_to_vehid = defaultdict(lambda: [])
-        for key, veh in W_orig.VEHICLES.items():
-            dict_od_to_vehid[veh.orig.name, veh.dest.name].append(key)
 
         if W_orig.finalized == False:
             W_orig.finalize_scenario()

--- a/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
+++ b/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
@@ -10,6 +10,7 @@ lightweight finalize, etc.). The pure-Python solvers live in ``DTAsolvers.py``.
 instances of the classes defined here via a lazy import in the base class ``__new__``,
 so this module is not imported when only the pure-Python solvers are used.
 """
+import copy
 import random
 import time
 import warnings
@@ -444,6 +445,7 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
         cached_analyzer = None
         prev_rs_link_ids = None
         prev_rs_offsets = None
+        best_avg_tt = None
 
         print("solving DSO...")
         for i in range(max_iter):
@@ -469,9 +471,13 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
             W.dict_od_to_routes = dict_od_to_routes
 
             if unfinished_trips == 0:
-                if s.W_intermid_solution is None:
-                    s.W_intermid_solution = W
-                elif W.analyzer.average_travel_time < s.W_intermid_solution.analyzer.average_travel_time:
+                # The Analyzer object is shared across iterations (rebound in
+                # _lightweight_finalize), so compare against a saved scalar and
+                # detach the best W's analyzer by shallow copy to freeze its stats.
+                avg_tt = W.analyzer.average_travel_time
+                if s.W_intermid_solution is None or avg_tt < best_avg_tt:
+                    best_avg_tt = avg_tt
+                    W.analyzer = copy.copy(W.analyzer)
                     s.W_intermid_solution = W
 
             s.dfs_link.append(W.analyzer.link_to_pandas())

--- a/uxsim/trafficpp/dta_solver.cpp
+++ b/uxsim/trafficpp/dta_solver.cpp
@@ -156,11 +156,12 @@ RouteSwapResult dta_route_swap_due(
         auto traveled = dta_get_traveled_route(veh);
         result.route_actual[vi] = traveled.link_ids;
 
-        // Compute travel time (arrival - first entry)
-        if (!traveled.entry_times.empty() && traveled.arrival_time >= 0){
+        // Compute travel time as Python's ts[-1] - ts[0]: arrival_time is -1
+        // for unfinished vehicles, and both terms coincide if no link was entered.
+        if (!traveled.entry_times.empty()){
             result.cost_actual[vi] = traveled.arrival_time - traveled.entry_times[0];
         } else {
-            result.cost_actual[vi] = -1;
+            result.cost_actual[vi] = 0;
         }
 
         // Skip vehicles that didn't finish their trip (leave empty = no enforce_route)
@@ -296,11 +297,11 @@ RouteSwapResult dta_route_swap_dso(
         auto traveled = dta_get_traveled_route(veh);
         result.route_actual[vi] = traveled.link_ids;
 
-        // Compute travel time
-        if (!traveled.entry_times.empty() && traveled.arrival_time >= 0){
+        // Compute travel time as Python's ts[-1] - ts[0] (see DUE above)
+        if (!traveled.entry_times.empty()){
             result.cost_actual[vi] = traveled.arrival_time - traveled.entry_times[0];
         } else {
-            result.cost_actual[vi] = -1;
+            result.cost_actual[vi] = 0;
         }
 
         // Skip vehicles that didn't finish their trip (leave empty = no enforce_route)


### PR DESCRIPTION
## Summary

This PR fixes three behavioral inconsistencies between the C++ accelerated DTA solvers (`SolverDUE`/`SolverDSO_D2D` with `cpp=True`) and the Python reference implementation, found by a line-by-line comparison of the two implementations. The Python solvers are treated as the source of truth.

### 1. `dfs_link` was only recorded on the last iteration

The C++ solvers only appended the link-level DataFrame to `dfs_link` on the last iteration, while the Python solvers record it every iteration. Code accessing per-iteration entries raised `IndexError`, e.g. `solver_DSO.dfs_link[best_idx]` in `example_28en_benchmark_cpp_mode.py`:

```
  File "example_28en_benchmark_cpp_mode.py", line 216, in run_due_dso
    results["_dso_link_df"] = solver_DSO.dfs_link[best_idx]
IndexError: list index out of range
```

Fixed by appending `W.analyzer.link_to_pandas()` every iteration. This works on intermediate iterations because the underlying data (`cum_arrival`, `cum_departure`, `traveltime_actual`) is read directly from the C++ engine and does not depend on the skipped vehicle-log construction.

### 2. `CppSolverDSO_D2D` best-solution tracking was broken

The C++ adapter reuses a single `Analyzer` object across iterations (rebound in `_lightweight_finalize` to skip expensive re-initialization). As a result, the Python-inherited comparison

```python
W.analyzer.average_travel_time < s.W_intermid_solution.analyzer.average_travel_time
```

compared the same object with itself and was always False. `W_intermid_solution` (and thus the returned `W_sol`) stayed at the *first* feasible iteration instead of the *best* one, and its `analyzer` reported the *last* iteration's stats. Fixed by tracking the best average travel time in a scalar and detaching the best W's analyzer via shallow copy to freeze its stats. Verified with high `swap_prob` runs where the best iteration is a mid-run one: `W_sol.analyzer.total_travel_time` now always equals `min(solver.ttts)`.

### 3. `cost_actual` for unfinished vehicles

Python computes `cost_actual` as `ts[-1] - ts[0]` from `Vehicle.traveled_route()`, which yields `-1 - first_link_entry_time` for unfinished vehicles and `0` when no link was entered. C++ returned `-1` for both cases. Matched to the Python definition (verified per-vehicle against `traveled_route()` on a congested scenario with 85/308 unfinished vehicles).

Additionally, `example_28en_benchmark_cpp_mode.py` now passes `cpp=cpp` to `SolverDUE`/`SolverDSO_D2D` so the C++ benchmark actually exercises the C++ solver path (previously it used the pure-Python solver loop even in C++ mode).

## Changes

- `uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py`: append `dfs_link` every iteration; fix DSO best-solution tracking with scalar comparison + analyzer detach; remove the unused `dict_od_to_vehid` construction (built but never read in the C++ path)
- `uxsim/trafficpp/dta_solver.cpp`: match Python's `cost_actual` definition for unfinished vehicles (DUE and DSO route swap)
- `demos_and_examples/example_28en_benchmark_cpp_mode.py`: pass `cpp=cpp` to the DTA solvers
- `tests/test_cpp_mode.py`: add 3 tests — per-iteration `dfs_link`, DSO best-solution tracking under oscillating TTT, and `cost_actual` consistency with `traveled_route()` including unfinished vehicles

## Verification

- **Regression tests**: `tests/test_cpp_mode.py` — 205 passed (re-run after each commit)
- **Example 28 full run** (`N_SEEDS=2`, `OMP_NUM_THREADS=1`): completes without error, including the previously failing `dfs_link[best_idx]` access
- **Python vs C++ validity** (example 28, DUE/DSO 9x9 grid, max_iter=100, 2 seeds):
  - DUE final TTT: Python 6,077,150 vs C++ 5,890,950 (3.1% diff)
  - DSO best TTT: Python 5,324,550 vs C++ 5,256,150 (1.3% diff)
  - Link-level accuracy (seed-averaged corr): DUE traffic_volume 0.981 / delay_ratio 0.930; DSO 0.981 / 0.838
- **Benchmark** (example 28, 1 thread): speedup Python/C++ — small 5.68x, large 24.45x, due_dso total **13.73x** (was 6.32x when the benchmark unintentionally used the Python solver loop)
- **Overhead of the fixes** (9x9 grid, max_iter=100, 5 seeds, 1 thread, alternating A/B runs x3): no measurable difference — WITH-fix vs WITHOUT-fix medians differ by less than the run-to-run noise (e.g. round-wise DUE 6.03/6.46/6.60s vs 6.21/6.44/6.55s)

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
