### PR TITLE
Match C++ route search edge cases to Python

### DIFF
--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8106,6 +8106,62 @@ def test_dta_solver_dfs_link_per_iteration_cpp():
             assert (df["delay_ratio"][df["traffic_volume"] > 0] > 0).all()
 
 
+def test_route_choice_avoids_closed_link_cpp():
+    """Links with capacity_in=0 get infinite route cost, so vehicles route around them (like Python)."""
+    def create_World(cpp):
+        W = uxsim.World(name="", deltan=5, tmax=2000, print_mode=0, save_mode=0,
+                        show_mode=0, random_seed=0, cpp=cpp)
+        W.addNode("O", 0, 0)
+        W.addNode("A", 1, 1)
+        W.addNode("B", 1, -1)
+        W.addNode("D", 2, 0)
+        # short route via A, but its second link is closed
+        W.addLink("OA", "O", "A", length=1000, free_flow_speed=20)
+        W.addLink("AD", "A", "D", length=1000, free_flow_speed=20, capacity_in=0)
+        # long open detour via B
+        W.addLink("OB", "O", "B", length=2000, free_flow_speed=20)
+        W.addLink("BD", "B", "D", length=2000, free_flow_speed=20)
+        W.adddemand("O", "D", 0, 500, 0.3)
+        return W
+
+    results = {}
+    for cpp in [False, True]:
+        W = create_World(cpp)
+        W.exec_simulation()
+        df = W.analyzer.link_to_pandas().set_index("link")
+        results[cpp] = df
+        assert W.analyzer.trip_completed == 150
+        assert df.loc["AD", "traffic_volume"] == 0
+    assert results[True].loc["BD", "traffic_volume"] == results[False].loc["BD", "traffic_volume"]
+
+
+def test_route_choice_parallel_links_averaged_cpp():
+    """Travel times of multiple links between the same node pair are averaged for routing (like Python)."""
+    def create_World(cpp):
+        W = uxsim.World(name="", deltan=5, tmax=2000, print_mode=0, save_mode=0,
+                        show_mode=0, random_seed=0, cpp=cpp)
+        W.addNode("O", 0, 0)
+        W.addNode("M", 1, 1)
+        W.addNode("D", 2, 0)
+        # direct pair O->D: fast (50 s) + slow (300 s), average 175 s
+        W.addLink("direct_fast", "O", "D", length=1000, free_flow_speed=20)
+        W.addLink("direct_slow", "O", "D", length=1500, free_flow_speed=5)
+        # bypass via M: 250 s total. Averaging (175 s) prefers the direct pair;
+        # last-link-wins (300 s) would wrongly prefer the bypass.
+        W.addLink("OM", "O", "M", length=2500, free_flow_speed=20)
+        W.addLink("MD", "M", "D", length=2500, free_flow_speed=20)
+        W.adddemand("O", "D", 0, 500, 0.2)
+        return W
+
+    for cpp in [False, True]:
+        W = create_World(cpp)
+        W.exec_simulation()
+        df = W.analyzer.link_to_pandas().set_index("link")
+        assert W.analyzer.trip_completed == 100
+        assert df.loc["OM", "traffic_volume"] == 0
+        assert df.loc["direct_fast", "traffic_volume"] + df.loc["direct_slow", "traffic_volume"] == 100
+
+
 @pytest.mark.flaky(reruns=5)
 def test_dta_solver_dso_d2d_grid_cpp_vs_python():
     """SolverDSO_D2D on 9x9 grid: C++ and Python produce similar TTT."""

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -554,7 +554,7 @@ void Link::set_travel_time(){
             vsum += veh->v;
         }
         double avg_v = vsum / (double)vehicles.size();
-        if (avg_v > vmax / 100.0){
+        if (avg_v > 0.0){
             traveltime_instant[w->timestep] = (double)length / avg_v;
         }else{
             traveltime_instant[w->timestep] = (double)length / (vmax / 100.0);
@@ -1154,6 +1154,15 @@ void World::initialize_adj_matrix(){
 
 void World::update_adj_time_matrix(){
     double noise = route_choice_uncertainty;
+    // Reset the cells written by links (running-average state). Matches Python's
+    // route_search_all, which rebuilds adj_mat_time from a zero matrix each call.
+    if (adj_mat_link_count.size() != nodes.size()){
+        adj_mat_link_count.assign(nodes.size(), vector<int>(nodes.size(), 0));
+    }
+    for (auto ln : links){
+        adj_mat_time[ln->start_node->id][ln->end_node->id] = 0.0;
+        adj_mat_link_count[ln->start_node->id][ln->end_node->id] = 0;
+    }
     for (auto ln : links){
         int i = ln->start_node->id;
         int j = ln->end_node->id;
@@ -1166,11 +1175,20 @@ void World::update_adj_time_matrix(){
         if (!ln->toll_timeseries.empty() && timestep < (int)ln->toll_timeseries.size()){
             penalty = ln->toll_timeseries[timestep];
         }
+        double new_link_tt;
         if (hard_deterministic_mode){
-            adj_mat_time[i][j] = tt + penalty;
+            new_link_tt = tt + penalty;
         } else {
             double noise_factor = random_range_float64(1.0, 1.0 + noise, rng);
-            adj_mat_time[i][j] = tt * noise_factor + penalty;
+            new_link_tt = tt * noise_factor + penalty;
+        }
+        // If there are multiple links between the same nodes, average the travel time
+        double n = (double)adj_mat_link_count[i][j];
+        adj_mat_time[i][j] = adj_mat_time[i][j] * n / (n + 1.0) + new_link_tt / (n + 1.0);
+        adj_mat_link_count[i][j] += 1;
+        // If the inflow is prohibited, travel time is assumed to be infinite
+        if (ln->capacity_in == 0.0){
+            adj_mat_time[i][j] = std::numeric_limits<double>::infinity();
         }
     }
 }

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -327,6 +327,7 @@ struct World {
     // Graph adjacency
     vector<vector<int>> adj_mat;
     vector<vector<double>> adj_mat_time;
+    vector<vector<int>> adj_mat_link_count;    // scratch for multi-link averaging in update_adj_time_matrix
     vector<vector<int>> route_next;
     vector<vector<double>> route_dist;
     map<int, vector<vector<double>>> route_dist_record;


### PR DESCRIPTION
## Summary

Three fidelity fixes in the C++ engine's dynamic route cost computation, matching Python's `RouteChoice.route_search_all` and `Link.set_traveltime_instant`. These were found during a line-by-line comparison of the two implementations (triggered by an investigation of Python-vs-C++ link-level correlation, which itself turned out to be pure seed variance — see Verification below).

### 1. Links with `capacity_in=0` get infinite route cost

Python assigns infinite cost to links whose inflow is prohibited (`uxsim.py` `route_search_all`), so vehicles route around closed links. The C++ router ignored `capacity_in`, kept guiding vehicles onto the closed link, and deadlocked them at its entrance. On a test network with a closed short route and an open detour, old C++ completed **0** trips; fixed C++ completes all 150, identical to Python.

### 2. Multiple links between the same node pair are averaged

Python averages the travel times of parallel links between the same node pair in the adjacency matrix. C++ let the last processed link overwrite the cell, which can flip route choice. On a test network where the direct pair (fast 50 s + slow 300 s, average 175 s) competes with a 250 s bypass, old C++ sent all vehicles to the bypass; fixed C++ chooses the direct pair, identical to Python.

### 3. Instantaneous travel time is not clipped at `vmax/100`

Python computes `length/avg_speed` whenever the average speed on the link is positive, so heavily congested links get very large route costs. C++ clipped speeds below `vmax/100` to `length/(vmax/100)`, capping the penalty of near-gridlocked links. C++ now matches Python's formula (the `length/(vmax/100)` fallback remains for `avg_speed == 0`, same as Python).

## Changes

- `uxsim/trafficpp/traffi.cpp`: `World::update_adj_time_matrix` — multi-link averaging + `capacity_in==0` → inf; `Link::set_travel_time` — clip condition `avg_v > vmax/100` → `avg_v > 0`
- `uxsim/trafficpp/traffi.h`: add `adj_mat_link_count` scratch matrix for the averaging
- `tests/test_cpp_mode.py`: add 2 tests (closed-link rerouting, parallel-link averaging), each asserting C++ behavior matches Python on deterministic networks

## Verification

- **Regression tests**: `tests/test_cpp_mode.py` — 207 passed (5 flaky reruns)
- **Validity**: 11x11 grid DUO scenario (example 28 "large", 5 seeds, 1 thread): fixed C++ TTT mean 9.06e7 ± 5.2e6 vs Python 15-seed reference 9.25e7 ± 4.4e6 — statistically indistinguishable (a 15-seed × 2-mode experiment confirmed within-Python, within-C++, and cross-mode link-level correlations are all equal, i.e. no systematic difference; per-seed results on this scenario are bit-identical before/after this PR since the edge cases do not occur there)
- **Benchmark** (9x9 grid DUE/DSO, max_iter=100, 5 seeds, 1 thread, median): DUE 5.58 s, DSO 6.26 s — within the pre-fix run-to-run band (5.35–6.68 s), no measurable overhead

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)