### PR TITLE
Match C++ engine behavior to Python core simulator

### DIFF
--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -7666,7 +7666,9 @@ def test_coverage_addVehicle_taxi_and_links_avoid():
         W.addVehicle("orig", "dest", 0, mode="taxi")
 
     W.addVehicle("orig", "dest", 0, links_avoid=[link1])
-    W.exec_simulation()
+    # links_avoid excludes the only outgoing link of the origin node, so vehicle generation raises ValueError (same as Python mode).
+    with pytest.raises(ValueError):
+        W.exec_simulation()
     assert len(W.VEHICLES) >= 1
 
 
@@ -7812,8 +7814,7 @@ def test_coverage_signal_capacity_enforce_route():
 
 def test_coverage_per_vehicle_log_mid_simulation():
     """Access vehicle log properties mid-simulation.
-    Verifies that log data is accessible during iterative execution
-    and that post-simulation analysis still works correctly afterward."""
+    Verifies that log data is accessible during iterative execution and that post-simulation analysis still works correctly afterward."""
     W = World(cpp=True, deltan=5, tmax=300, print_mode=0, save_mode=0, show_mode=0, random_seed=42)
     W.addNode("A", 0, 0)
     W.addNode("B", 1000, 0)
@@ -7875,8 +7876,7 @@ def test_coverage_main_loop_parameter_branches():
 
 def test_coverage_route_choice_edge_cases():
     """Test route_next_link_choice with unreachable destination.
-    A vehicle heading to an isolated node cannot find a route at the origin,
-    triggering the route_next_link == nullptr branch in Node::generate."""
+    A vehicle heading to an isolated node cannot find a route at the origin, triggering the route_next_link == nullptr branch in Node::generate."""
     W = World(cpp=True, deltan=5, tmax=200, print_mode=0, save_mode=0, show_mode=0, random_seed=42)
     W.addNode("orig", 0, 0)
     W.addNode("mid", 1, 0)
@@ -8146,8 +8146,8 @@ def test_route_choice_parallel_links_averaged_cpp():
         # direct pair O->D: fast (50 s) + slow (300 s), average 175 s
         W.addLink("direct_fast", "O", "D", length=1000, free_flow_speed=20)
         W.addLink("direct_slow", "O", "D", length=1500, free_flow_speed=5)
-        # bypass via M: 250 s total. Averaging (175 s) prefers the direct pair;
-        # last-link-wins (300 s) would wrongly prefer the bypass.
+        # bypass via M: 250 s total.
+        # Averaging (175 s) prefers the direct pair; last-link-wins (300 s) would wrongly prefer the bypass.
         W.addLink("OM", "O", "M", length=2500, free_flow_speed=20)
         W.addLink("MD", "M", "D", length=2500, free_flow_speed=20)
         W.adddemand("O", "D", 0, 500, 0.2)
@@ -8274,8 +8274,7 @@ def test_dta_solver_dso_d2d_grid_benchmark_cpp():
 
 
 # ======================================================================
-# traveltime_actual lazy materialization: intervention reads at chunk
-# boundaries must not change results (Round 5, Phase 2)
+# traveltime_actual lazy materialization: intervention reads at chunk boundaries must not change results (Round 5, Phase 2)
 # ======================================================================
 
 def _create_merge_world_for_tt_read_test():
@@ -8294,10 +8293,7 @@ def _create_merge_world_for_tt_read_test():
 
 
 def test_traveltime_actual_intervention_read_chunked():
-    """Reading traveltime_actual mid-simulation (at exec_simulation chunk
-    boundaries) must return valid values and must not alter the final
-    results compared to (a) a one-shot run and (b) a chunked run without
-    intervention reads."""
+    """Reading traveltime_actual mid-simulation (at exec_simulation chunk boundaries) must return valid values and must not alter the final results compared to (a) a one-shot run and (b) a chunked run without intervention reads."""
     # (a) one-shot reference
     W_ref = _create_merge_world_for_tt_read_test()
     W_ref.exec_simulation()
@@ -8324,10 +8320,7 @@ def test_traveltime_actual_intervention_read_chunked():
             snapshot[l.name] = arr
         boundary_tts.append(snapshot)
 
-    # mid-simulation snapshots must be consistent with the final state:
-    # once recorded, past values only change due to later link exits, so at
-    # minimum the free-flow default must have been overwritten identically
-    # wherever congestion was observed in both runs
+    # mid-simulation snapshots must be consistent with the final state: once recorded, past values only change due to later link exits, so at minimum the free-flow default must have been overwritten identically wherever congestion was observed in both runs
     for l in W_read.LINKS:
         final_arr = np.asarray(l._cpp_link.get_traveltime_actual_np())
         ref_arr = tt_ref[l.name]
@@ -8343,24 +8336,14 @@ def test_traveltime_actual_intervention_read_chunked():
 
 
 # ======================================================================
-# Chunked exec_simulation with mid-simulation analyst reads and
-# interventions: reads must not perturb results, and mid-simulation logs
-# must satisfy structural invariants
+# Chunked exec_simulation with mid-simulation analyst reads and interventions: reads must not perturb results, and mid-simulation logs must satisfy structural invariants
 # ======================================================================
 
 def test_chunked_exec_with_midsim_reads_and_interventions():
-    """Chunked execution (exec_simulation(duration_t2=...)) with an analyst
-    intervening at every chunk boundary (reading vehicle logs, reading link
-    travel times, adding demand, changing free-flow speed) must:
-      1. produce results with no side effects from the reads: a run that
-         reads at every boundary and a run that does not must yield exactly
-         identical final results (total travel time, per-vehicle travel/
-         arrival times, per-vehicle logs, per-link actual travel times);
-      2. return mid-simulation logs that satisfy structural invariants
-         (equal-length log arrays, uniform DELTAT time stepping, monotone
-         non-decreasing vehicle state).
-    This is a regression test for the C++ engine's lazy log reconstruction
-    and vehicle-list management.
+    """Chunked execution (exec_simulation(duration_t2=...)) with an analyst intervening at every chunk boundary (reading vehicle logs, reading link travel times, adding demand, changing free-flow speed) must:
+      1. produce results with no side effects from the reads: a run that reads at every boundary and a run that does not must yield exactly identical final results (total travel time, per-vehicle travel/arrival times, per-vehicle logs, per-link actual travel times);
+      2. return mid-simulation logs that satisfy structural invariants (equal-length log arrays, uniform DELTAT time stepping, monotone non-decreasing vehicle state).
+    This is a regression test for the C++ engine's lazy log reconstruction and vehicle-list management.
     """
     IMAX = JMAX = 9
 
@@ -8382,8 +8365,7 @@ def test_chunked_exec_with_midsim_reads_and_interventions():
                               length=1000, free_flow_speed=20, jam_density=0.2)
                     W.addLink(f"l{i}.{j+1}.{i}.{j}", f"n{i}.{j+1}", f"n{i}.{j}",
                               length=1000, free_flow_speed=20, jam_density=0.2)
-        # boundary-to-boundary OD: left column <-> right column and
-        # bottom row <-> top row, all pairs, both directions
+        # boundary-to-boundary OD: left column <-> right column and bottom row <-> top row, all pairs, both directions
         for j1 in range(JMAX):
             for j2 in range(JMAX):
                 W.adddemand(f"n0.{j1}", f"n{IMAX-1}.{j2}", 0, 2400, 0.035)
@@ -8410,9 +8392,7 @@ def test_chunked_exec_with_midsim_reads_and_interventions():
             if k == 3:
                 W.get_link("l4.4.4.5").change_free_flow_speed(10)
             if do_reads:
-                # The current C++ wrapper does not invalidate a once-built log
-                # cache (known limitation), so reset every vehicle's cache each
-                # time to force the lazy reconstruction path to run again.
+                # The current C++ wrapper does not invalidate a once-built log cache (known limitation), so reset every vehicle's cache each time to force the lazy reconstruction path to run again.
                 for veh in W.VEHICLES.values():
                     veh._log_cache = None
                 vehs = list(W.VEHICLES.values())
@@ -8428,9 +8408,7 @@ def test_chunked_exec_with_midsim_reads_and_interventions():
                     log_t = np.asarray(log_t, dtype=float)
                     if len(log_t) > 1:
                         diffs = np.diff(log_t)
-                        # every step is DELTAT, except that trip end records
-                        # repeated entries at the same final timestep, which
-                        # appear only as a trailing run of zero diffs
+                        # every step is DELTAT, except that trip end records repeated entries at the same final timestep, which appear only as a trailing run of zero diffs
                         assert set(np.unique(diffs)).issubset({0.0, float(W.DELTAT)})
                         if np.any(diffs == 0):
                             first_zero = int(np.argmax(diffs == 0))
@@ -8450,9 +8428,7 @@ def test_chunked_exec_with_midsim_reads_and_interventions():
     W_read = run(do_reads=True)
     W_noread = run(do_reads=False)
 
-    # Reset caches before the final comparison: Run A (W_read) may retain
-    # caches built during interventions before termination, so force a fresh
-    # reconstruction on both runs before reading.
+    # Reset caches before the final comparison: Run A (W_read) may retain caches built during interventions before termination, so force a fresh reconstruction on both runs before reading.
     for W in (W_read, W_noread):
         for veh in W.VEHICLES.values():
             veh._log_cache = None
@@ -8478,13 +8454,9 @@ def test_chunked_exec_with_midsim_reads_and_interventions():
 
 
 def test_vehicle_log_python_cpp_equivalence():
-    """Vehicle logs (log_t/log_state/log_x/log_v/log_lane/log_t_link) must match
-    between Python mode and C++ mode on a deterministic scenario (every node has
-    out-degree <= 1, so routing does not depend on the RNG).
+    """Vehicle logs (log_t/log_state/log_x/log_v/log_lane/log_t_link) must match between Python mode and C++ mode on a deterministic scenario (every node has out-degree <= 1, so routing does not depend on the RNG).
 
-    This is a regression test for the log-entry structure at trip termination:
-    the final timestep records exactly two entries (a RUN entry followed by an
-    END entry), and the END state is recorded exactly once via end_trip.
+    This is a regression test for the log-entry structure at trip termination: the final timestep records exactly two entries (a RUN entry followed by an END entry), and the END state is recorded exactly once via end_trip.
     """
 
     def build_world(cpp, scenario):
@@ -8502,13 +8474,10 @@ def test_vehicle_log_python_cpp_equivalence():
         W.addLink("AB", "A", "B", length=1000, free_flow_speed=20, jam_density=0.2)
         W.addLink("BC", "B", "C", length=1000, free_flow_speed=20, jam_density=0.2)
         if scenario == 1:
-            # normal termination through a congested corridor A->B->C:
-            # congestion exercises both the update()-path and the transfer()-path
-            # to trip termination
+            # normal termination through a congested corridor A->B->C: congestion exercises both the update()-path and the transfer()-path to trip termination
             W.adddemand("A", "C", 0, 1500, 0.5)
         else:
-            # abort path: D is an isolated node (no links), so vehicles bound for
-            # D reach the dead end at C and abort
+            # abort path: D is an isolated node (no links), so vehicles bound for D reach the dead end at C and abort
             W.addNode("D", 3, 0)
             W.adddemand("A", "D", 0, 1500, 0.5)
         W.exec_simulation()
@@ -8553,9 +8522,7 @@ def test_vehicle_log_python_cpp_equivalence():
                 np.asarray(vcpp.log_lane),
             ), f"[{name}] log_lane mismatch"
 
-            # log_x / log_v: allclose with atol=1e-9 as insurance against
-            # floating-point differences on heterogeneous CI platforms; these
-            # match exactly locally
+            # log_x / log_v: allclose with atol=1e-9 as insurance against floating-point differences on heterogeneous CI platforms; these match exactly locally
             for k in ("log_x", "log_v"):
                 apy = np.asarray(getattr(vpy, k), dtype=float)
                 acpp = np.asarray(getattr(vcpp, k), dtype=float)
@@ -8570,3 +8537,106 @@ def test_vehicle_log_python_cpp_equivalence():
             # travel_time
             assert vpy.travel_time == vcpp.travel_time, \
                 f"[{name}] travel_time mismatch"
+
+
+# ======================================================================
+# Python/C++ equivalence tests for auto-TMAX and partial execution
+# ======================================================================
+
+def test_auto_tmax_python_cpp_equivalence():
+    """Auto-determined TMAX (tmax=None) must match between Python mode and C++ mode.
+
+    TMAX must be derived from the latest vehicle departure time, as Python's finalize_scenario does.
+    Deriving it from the demand end time instead gives a different value when t_end is an exact multiple of 1800 s (e.g., 5400 instead of 3600 for t_end=1800), because the last vehicle departs slightly before t_end.
+    """
+    def build_and_run(cpp):
+        W = World(name="", deltan=5, reaction_time=1, print_mode=0, save_mode=0, show_mode=0,
+                  random_seed=0, cpp=cpp)
+        W.addNode("A", 0, 0)
+        W.addNode("B", 1, 0)
+        W.addLink("L", "A", "B", length=1000, free_flow_speed=20, jam_density=0.2)
+        W.adddemand("A", "B", 0, 1800, 0.3)
+        ret = W.exec_simulation()
+        return W, ret
+
+    Wpy, ret_py = build_and_run(False)
+    Wcpp, ret_cpp = build_and_run(True)
+
+    assert ret_py == ret_cpp == 1
+    assert Wpy.TMAX == Wcpp.TMAX
+    assert Wpy.TSIZE == Wcpp.TSIZE
+    assert Wpy.T == Wcpp.T
+    assert len(Wpy.VEHICLES) == len(Wcpp.VEHICLES)
+    comp_py = len([v for v in Wpy.VEHICLES.values() if v.arrival_time != -1])
+    comp_cpp = len([v for v in Wcpp.VEHICLES.values() if v.arrival_time != -1])
+    assert comp_py == comp_cpp
+
+
+def test_auto_tmax_beyond_default_horizon_python_cpp_equivalence():
+    """With tmax=None and demand beyond 7200 s, C++ mode must simulate the full auto-determined horizon and terminate.
+
+    The C++ world is created with a placeholder horizon of 7200 s before TMAX is known, and finalize_scenario must resize it to the final TMAX.
+    If the resize is skipped, the simulation stops at 7200 s, exec_simulation() keeps returning 0, and check_simulation_ongoing() stays True forever, so a `while W.check_simulation_ongoing()` loop never ends.
+    """
+    def build_and_run(cpp):
+        W = World(name="", deltan=5, reaction_time=1, print_mode=0, save_mode=0, show_mode=0,
+                  random_seed=0, cpp=cpp)
+        W.addNode("A", 0, 0)
+        W.addNode("B", 1, 0)
+        W.addLink("L", "A", "B", length=1000, free_flow_speed=20, jam_density=0.2)
+        W.adddemand("A", "B", 7000, 8000, 0.3)
+        ret = W.exec_simulation()
+        return W, ret
+
+    Wpy, ret_py = build_and_run(False)
+    Wcpp, ret_cpp = build_and_run(True)
+
+    assert ret_py == ret_cpp == 1
+    assert Wpy.TMAX == Wcpp.TMAX
+    assert Wpy.T == Wcpp.T == Wpy.TSIZE
+    assert Wcpp.check_simulation_ongoing() == Wpy.check_simulation_ongoing() == False
+    comp_py = len([v for v in Wpy.VEHICLES.values() if v.arrival_time != -1])
+    comp_cpp = len([v for v in Wcpp.VEHICLES.values() if v.arrival_time != -1])
+    assert comp_py == comp_cpp
+    assert comp_py == len(Wpy.VEHICLES)  # all vehicles complete their trips
+
+
+def test_exec_simulation_partial_run_python_cpp_equivalence():
+    """W.T and W.TIME after partial executions (until_t / duration_t / duration_t2) must match between Python mode and C++ mode at every chunk boundary, and the final results must match.
+
+    This guards the conversion of the duration parameters into the C++ engine's until_t: an off-by-one conversion executes one extra timestep per chunk.
+    It also guards the TIME convention: TIME must equal T*DELTAT (the next timestep to execute), not the last executed timestep times DELTAT.
+    """
+    def build(cpp):
+        W = World(name="", deltan=5, reaction_time=1, tmax=1500, print_mode=0, save_mode=0,
+                  show_mode=0, random_seed=0, cpp=cpp)
+        W.addNode("A", 0, 0)
+        W.addNode("B", 1, 0)
+        W.addNode("C", 2, 0)
+        W.addLink("AB", "A", "B", length=1000, free_flow_speed=20, jam_density=0.2)
+        W.addLink("BC", "B", "C", length=1000, free_flow_speed=20, jam_density=0.2, capacity_out=0.4)
+        W.adddemand("A", "C", 0, 1000, 0.6)
+        return W
+
+    for kwargs_list in (
+        [dict(until_t=100), dict(until_t=400), dict(until_t=453)],
+        [dict(duration_t=100)] * 3,
+        [dict(duration_t2=100)] * 3,
+        [dict(duration_t2=98), dict(duration_t=98), dict(until_t=777)],
+    ):
+        Wpy = build(False)
+        Wcpp = build(True)
+        for kwargs in kwargs_list:
+            ret_py = Wpy.exec_simulation(**kwargs)
+            ret_cpp = Wcpp.exec_simulation(**kwargs)
+            assert ret_py == ret_cpp, f"{kwargs_list}: return value mismatch at {kwargs}"
+            assert Wpy.T == Wcpp.T, f"{kwargs_list}: T mismatch at {kwargs}: {Wpy.T} vs {Wcpp.T}"
+            assert Wpy.TIME == Wcpp.TIME, f"{kwargs_list}: TIME mismatch at {kwargs}: {Wpy.TIME} vs {Wcpp.TIME}"
+        # run to completion and compare final results
+        assert Wpy.exec_simulation() == Wcpp.exec_simulation() == 1
+        assert Wpy.T == Wcpp.T
+        assert Wpy.TIME == Wcpp.TIME
+        Wpy.analyzer.basic_analysis()
+        Wcpp.analyzer.basic_analysis()
+        assert eq_tol(Wpy.analyzer.total_travel_time, Wcpp.analyzer.total_travel_time, rel_tol=0.02)
+        assert Wpy.analyzer.trip_completed == Wcpp.analyzer.trip_completed

--- a/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
+++ b/uxsim/DTAsolvers/DTAsolvers_cpp_adapter.py
@@ -1,14 +1,10 @@
 """
 C++ engine adapter for Dynamic Traffic Assignment solvers.
 
-This module contains everything specific to the C++ engine (``World(cpp=True)``):
-the C++ accelerated solver classes (:class:`CppSolverDUE`, :class:`CppSolverDSO_D2D`)
-and their helper functions (id<->name conversion, nested-CSR route handling,
-lightweight finalize, etc.). The pure-Python solvers live in ``DTAsolvers.py``.
+This module contains everything specific to the C++ engine (``World(cpp=True)``): the C++ accelerated solver classes (:class:`CppSolverDUE`, :class:`CppSolverDSO_D2D`) and their helper functions (id<->name conversion, nested-CSR route handling, lightweight finalize, etc.).
+The pure-Python solvers live in ``DTAsolvers.py``.
 
-``SolverDUE(func_World, cpp=True)`` / ``SolverDSO_D2D(func_World, cpp=True)`` return
-instances of the classes defined here via a lazy import in the base class ``__new__``,
-so this module is not imported when only the pure-Python solvers are used.
+``SolverDUE(func_World, cpp=True)`` / ``SolverDSO_D2D(func_World, cpp=True)`` return instances of the classes defined here via a lazy import in the base class ``__new__``, so this module is not imported when only the pure-Python solvers are used.
 """
 import copy
 import random
@@ -37,8 +33,7 @@ def _ensure_cpp_world(W, solver_name="CppSolver"):
 def _lightweight_finalize(W, cached_analyzer=None):
     """Lightweight finalize_scenario for DTA intermediate iterations.
 
-    Performs essential initialization (TMAX, adj_matrix, TSIZE) but reuses
-    a cached Analyzer object to skip expensive font loading.
+    Performs essential initialization (TMAX, adj_matrix, TSIZE) but reuses a cached Analyzer object to skip expensive font loading.
 
     Parameters
     ----------
@@ -51,8 +46,9 @@ def _lightweight_finalize(W, cached_analyzer=None):
     Analyzer : the (possibly reused) Analyzer object now attached to W.
     """
     if W.TMAX is None:
-        W.TMAX = (getattr(W, '_max_demand_t', 0) // 1800 + 2) * 1800
+        W.TMAX = W._compute_auto_tmax()
     W._ensure_cpp_world()
+    W._cpp_world.set_t_max(float(W.TMAX))
     W._cpp_world.initialize_adj_matrix()
 
     # Minimal _setup_analyzer equivalent
@@ -110,8 +106,7 @@ def _lightweight_finalize(W, cached_analyzer=None):
 def _build_id_lookup_arrays(W):
     """Build id->name lookup arrays/dicts (indexed by C++ id) for a CppWorld.
 
-    Returns (link_name_to_id, link_id_to_name, node_name_to_id, node_id_to_name)
-    where the *_id_to_name are dicts keyed by C++ id.
+    Returns (link_name_to_id, link_id_to_name, node_name_to_id, node_id_to_name) where the *_id_to_name are dicts keyed by C++ id.
     """
     link_name_to_id = {link.name: link.id for link in W.LINKS}
     link_id_to_name = {link.id: link.name for link in W.LINKS}
@@ -123,10 +118,8 @@ def _build_id_lookup_arrays(W):
 class _LazyODRoutes(dict):
     """Lazy {(o_name, d_name): [[link_name, ...], ...]} built on first access.
 
-    The C++ solvers consume OD route sets purely as link IDs, so the name-form
-    dict is only needed if the solution World is later reused (e.g. as an
-    initial_solution_World for a Python solver, or by ALNS). Deferring its
-    construction avoids the per-solve name-building cost in the common case.
+    The C++ solvers consume OD route sets purely as link IDs, so the name-form dict is only needed if the solution World is later reused (e.g. as an initial_solution_World for a Python solver, or by ALNS).
+    Deferring its construction avoids the per-solve name-building cost in the common case.
     Subclasses dict so ``isinstance(x, dict)`` and normal dict access hold.
     """
     __slots__ = ("_csr", "_nid2n", "_lid2n", "_built")
@@ -180,9 +173,8 @@ class _LazyODRoutes(dict):
 def _build_od_name_dict_from_csr(csr, node_id_to_name, link_id_to_name):
     """Build {(o_name, d_name): [[link_name, ...], ...]} from nested-CSR arrays.
 
-    This reuses interned name string objects from the id->name dicts (no new
-    string allocation per element), so it is far cheaper than the per-element
-    nb::str construction of the name-based public API. Built once per solve.
+    This reuses interned name string objects from the id->name dicts (no new string allocation per element), so it is far cheaper than the per-element nb::str construction of the name-based public API.
+    Built once per solve.
     """
     od_o = csr['od_o']
     od_d = csr['od_d']
@@ -207,9 +199,7 @@ def _build_od_name_dict_from_csr(csr, node_id_to_name, link_id_to_name):
 def _convert_flat_result_to_names(result, veh_names, link_id_to_name):
     """Convert flat-CSR C++ route_swap result to name-keyed route_actual/cost_actual.
 
-    routes_specified is intentionally NOT converted to names here: it is kept in
-    flat ID-CSR form (rs_link_ids/rs_offsets) and fed directly back to
-    batch_enforce_routes_csr, avoiding a name<->id round-trip.
+    routes_specified is intentionally NOT converted to names here: it is kept in flat ID-CSR form (rs_link_ids/rs_offsets) and fed directly back to batch_enforce_routes_csr, avoiding a name<->id round-trip.
 
     Returns (route_actual_dict, cost_actual_dict, n_swap, potential_n_swap, total_t_gap).
     """
@@ -278,13 +268,11 @@ class CppSolverDUE(SolverDUE):
         if W_orig.finalized == False:
             W_orig.finalize_scenario()
 
-        # Build id<->name lookups once (node/link ids are stable across
-        # func_World() reconstructions, so W_orig's mapping is valid for all iters).
+        # Build id<->name lookups once (node/link ids are stable across func_World() reconstructions, so W_orig's mapping is valid for all iters).
         (link_name_to_id, link_id_to_name, node_name_to_id,
          node_id_to_name) = _build_id_lookup_arrays(W_orig)
 
-        # Draw the enumeration seed exactly as enumerate_k_random_routes() would,
-        # to preserve global-RNG consumption order (and thus bit-identical results).
+        # Draw the enumeration seed exactly as enumerate_k_random_routes() would, to preserve global-RNG consumption order (and thus bit-identical results).
         enum_seed = random.randint(0, 2**31 - 1)
 
         if route_sets is not None:
@@ -323,9 +311,7 @@ class CppSolverDUE(SolverDUE):
 
             cached_analyzer = _lightweight_finalize(W, cached_analyzer)
 
-            # Skip expensive log cache building on intermediate iterations;
-            # CppWorld log mode is set at __init__ time, so vehicle_logging_timestep_interval
-            # cannot be changed after construction — _skip_log_on_terminate handles this instead.
+            # Skip expensive log cache building on intermediate iterations; CppWorld log mode is set at __init__ time, so vehicle_logging_timestep_interval cannot be changed after construction — _skip_log_on_terminate handles this instead.
             if not is_last_iter:
                 W._skip_log_on_terminate = True
 
@@ -405,8 +391,7 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
         (link_name_to_id, link_id_to_name, node_name_to_id,
          node_id_to_name) = _build_id_lookup_arrays(W_orig)
 
-        # Draw the enumeration seed exactly as enumerate_k_random_routes() would,
-        # to preserve global-RNG consumption order (and thus bit-identical results).
+        # Draw the enumeration seed exactly as enumerate_k_random_routes() would, to preserve global-RNG consumption order (and thus bit-identical results).
         enum_seed = random.randint(0, 2**31 - 1)
 
         if route_sets is not None:
@@ -463,9 +448,7 @@ class CppSolverDSO_D2D(SolverDSO_D2D):
             W.dict_od_to_routes = dict_od_to_routes
 
             if unfinished_trips == 0:
-                # The Analyzer object is shared across iterations (rebound in
-                # _lightweight_finalize), so compare against a saved scalar and
-                # detach the best W's analyzer by shallow copy to freeze its stats.
+                # The Analyzer object is shared across iterations (rebound in _lightweight_finalize), so compare against a saved scalar and detach the best W's analyzer by shallow copy to freeze its stats.
                 avg_tt = W.analyzer.average_travel_time
                 if s.W_intermid_solution is None or avg_tt < best_avg_tt:
                     best_avg_tt = avg_tt

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -62,8 +62,7 @@ static void routes_to_csr(std::vector<std::vector<int>> &&routes,
 
 // ----------------------------------------------------------------------
 // Interned Python strings for state names.
-// Heap-allocated and explicitly cleaned up via atexit to avoid
-// static destruction order issues (segfault at interpreter shutdown).
+// Heap-allocated and explicitly cleaned up via atexit to avoid static destruction order issues (segfault at interpreter shutdown).
 // ----------------------------------------------------------------------
 struct InternedStrings {
     nb::str states[5];   // home, wait, run, end, abort
@@ -85,8 +84,7 @@ static InternedStrings *g_intern = nullptr;
 
 // ----------------------------------------------------------------------
 // Custom streambuf that redirects C++ output to Python sys.stdout.
-// Uses raw PyObject* instead of nb::object to avoid GIL issues
-// during static destruction at Python interpreter shutdown.
+// Uses raw PyObject* instead of nb::object to avoid GIL issues during static destruction at Python interpreter shutdown.
 // ----------------------------------------------------------------------
 class py_stdout_redirect_buf : public std::streambuf {
 public:
@@ -133,8 +131,7 @@ private:
 
 // ----------------------------------------------------------------------
 // Helper to get a Python-redirected ostream.
-// Uses heap allocation to control destruction order and avoid
-// static destruction crashes at interpreter shutdown.
+// Uses heap allocation to control destruction order and avoid static destruction crashes at interpreter shutdown.
 // ----------------------------------------------------------------------
 static py_stdout_redirect_buf *g_custom_buf = nullptr;
 static std::ostream *g_pyout = nullptr;
@@ -550,6 +547,11 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("vehicle_log_mode", &World::vehicle_log_mode)
         .def_ro("ave_v", &World::ave_v)
         .def_ro("ave_vratio", &World::ave_vratio)
+        .def_ro("ave_v_sum", &World::ave_v_sum)
+        .def_ro("stat_sample_count", &World::stat_sample_count)
+        .def("set_t_max", &World::set_t_max,
+             nb::arg("new_t_max"),
+             "Update t_max/total_timesteps and resize per-link time-indexed arrays (call before simulation start)")
         .def_ro("trips_total", &World::trips_total)
         .def_ro("trips_completed", &World::trips_completed)
         .def_ro("flag_initialized", &World::flag_initialized)
@@ -900,8 +902,7 @@ NB_MODULE(uxsim_cpp, m) {
     g_intern->init();
 
     // Register cleanup to run before Python interpreter shuts down.
-    // This ensures heap-allocated objects with Python references are
-    // destroyed while Py_IsInitialized() still returns true.
+    // This ensures heap-allocated objects with Python references are destroyed while Py_IsInitialized() still returns true.
     auto atexit = nb::module_::import_("atexit");
     atexit.attr("register")(nb::cpp_function([]() {
         delete g_intern;

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -301,8 +301,7 @@ void Node::transfer(){
         inlink->departure_curve[w->timestep] += w->delta_n;
         outlink->arrival_curve[w->timestep] += w->delta_n;
 
-        // Record traveltime_real event (lazily materialized on read,
-        // matching Python's traveltime_actual slice update)
+        // Record traveltime_real event (lazily materialized on read, matching Python's traveltime_actual slice update)
         {
             double current_tt = (double)w->timestep * w->delta_t - chosen_veh->arrival_time_link;
             int start_idx = (int)(chosen_veh->arrival_time_link / w->delta_t);
@@ -567,12 +566,9 @@ void Link::set_travel_time(){
 /**
  * @brief Materialize pending traveltime_real events into the array.
  *
- * Link-exit events are buffered as (start_idx, tt) pairs during the main
- * loop (write-only phase) and replayed here on first read. Replay rule:
- * event k fills [s_k, min(s_{k+1}, n)) and the last pending event fills
- * [s_k, n). This is equivalent to the eager behavior where each event
- * overwrites [s_k, n) in order: position i ends up with the value of the
- * last event whose s_k <= i, regardless of start_idx monotonicity.
+ * Link-exit events are buffered as (start_idx, tt) pairs during the main loop (write-only phase) and replayed here on first read.
+ * Replay rule: event k fills [s_k, min(s_{k+1}, n)) and the last pending event fills [s_k, n).
+ * This is equivalent to the eager behavior where each event overwrites [s_k, n) in order: position i ends up with the value of the last event whose s_k <= i, regardless of start_idx monotonicity.
  */
 void Link::ensure_traveltime_real() const {
     size_t n_events = traveltime_real_events.size();
@@ -723,6 +719,7 @@ Vehicle::Vehicle(
         log_x.reserve(log_cap);
         log_v.reserve(log_cap);
         log_lane.reserve(log_cap);
+        log_s.reserve(log_cap);
     }
 
     w->vehicles.push_back(this);
@@ -790,8 +787,7 @@ void Vehicle::end_trip(){
     w->trips_completed_count += 1.0;
     link->departure_curve[w->timestep] += w->delta_n;
 
-    // Record traveltime_real event (lazily materialized on read,
-    // matching Python's traveltime_actual slice update)
+    // Record traveltime_real event (lazily materialized on read, matching Python's traveltime_actual slice update)
     {
         double current_tt = ((double)w->timestep + 1.0) * w->delta_t - arrival_time_link;
         int start_idx = (int)(arrival_time_link / w->delta_t);
@@ -868,18 +864,18 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
         return;
     }
 
-    // specified_route: force next link from the route plan
+    // specified_route: force next link from the route plan.
+    // Inconsistencies raise the same exceptions as Python: IndexError (out_of_range) when the route is exhausted, ValueError (invalid_argument) when the forced link is not an outgoing link.
     if (!specified_route.empty()){
         int traveled = _traveled_link_count;
-        if (traveled < (int)specified_route.size()){
-            Link *forced = specified_route[traveled];
-            if (contains(linkset, forced)){
-                route_next_link = forced;
-                route_choice_flag_on_link = 1;
-                return;
-            }
+        if (traveled >= (int)specified_route.size()){
+            throw std::out_of_range("Vehicle " + name + ": specified route has no more links (index " + std::to_string(traveled) + " out of range for route of length " + std::to_string(specified_route.size()) + ")");
         }
-        route_next_link = nullptr;
+        Link *forced = specified_route[traveled];
+        if (!contains(linkset, forced)){
+            throw std::invalid_argument("Vehicle " + name + ": specified route is inconsistent; link " + forced->name + " is not an outgoing link of the current node");
+        }
+        route_next_link = forced;
         route_choice_flag_on_link = 1;
         return;
     }
@@ -900,7 +896,8 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
         }
     }
 
-    // Filter out links_avoid (subtraction from linkset)
+    // Filter out links_avoid (subtraction from linkset).
+    // As in Python, the subtraction applies whenever any outlink is avoided, even if the result becomes empty; an empty result raises ValueError.
     if (!links_avoid.empty()){
         _buf_filtered.clear();
         for (auto ln : outlinks){
@@ -908,8 +905,11 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
                 _buf_filtered.push_back(ln);
             }
         }
-        if (!_buf_filtered.empty()){
+        if (_buf_filtered.size() != outlinks.size()){
             outlinks.swap(_buf_filtered);
+        }
+        if (outlinks.empty()){
+            throw std::invalid_argument("Vehicle " + name + ": links_avoid excludes all outgoing links of the current node");
         }
     }
 
@@ -981,16 +981,18 @@ void Vehicle::record_travel_time(Link *link, double t){
 /**
  * @brief Log vehicle data for analysis.
  * Uses reserve'd arrays — push_back is O(1) with no reallocation.
- * log_size tracks actual count (vector::size() is equivalent but log_size
- * avoids any ambiguity if resize was used elsewhere).
+ * log_size tracks actual count (vector::size() is equivalent but log_size avoids any ambiguity if resize was used elsewhere).
  */
 void Vehicle::log_data(){
-    // Accumulate stats for print_simple_results (regardless of log mode)
+    // Accumulate stats for print_simple_results (regardless of log mode).
+    // A waiting vehicle counts as a zero-speed sample for the average speed statistic, as in Python's record_log.
     if (state == vsRUN){
         w->ave_v_sum += v;
         if (link){
             w->ave_vratio_sum += v / link->vmax;
         }
+        w->stat_sample_count += 1.0;
+    } else if (state == vsWAIT){
         w->stat_sample_count += 1.0;
     }
 
@@ -1004,22 +1006,22 @@ void Vehicle::log_data(){
             log_x.push_back(x);
             log_v.push_back(v);
             log_lane.push_back(lane);
+            log_s.push_back((leader != nullptr && leader->link == link) ? leader->x - x : -1.0);
         } else {
             log_link.push_back(-1);
             log_x.push_back(-1);
             log_v.push_back(-1);
             log_lane.push_back(-1);
+            log_s.push_back(-1.0);
         }
         log_size++;
     }
 }
 
 /**
- * @brief Reconstruct log_t entry i. Bit-identical to the eager version:
- * entries run one-per-timestep from log_first_ts, except the final END/ABORT
- * tail (recorded by end_trip()) which, on the update() path, duplicates the
- * timestep of the immediately preceding RUN entry (log_last_ts). Uses the same
- * (double)ts * delta_t expression as the eager push.
+ * @brief Reconstruct log_t entry i.
+ * Bit-identical to the eager version: entries run one-per-timestep from log_first_ts, except the final END/ABORT tail (recorded by end_trip()) which, on the update() path, duplicates the timestep of the immediately preceding RUN entry (log_last_ts).
+ * Uses the same (double)ts * delta_t expression as the eager push.
  */
 double Vehicle::log_t_at(size_t i) const {
     size_t tail = log_size - (size_t)log_end_count;
@@ -1029,8 +1031,8 @@ double Vehicle::log_t_at(size_t i) const {
 }
 
 /**
- * @brief Reconstruct log_state entry i. Log structure is always:
- * HOME x1, WAIT x log_wait_count, RUN x r, [END|ABORT] x log_end_count.
+ * @brief Reconstruct log_state entry i.
+ * Log structure is always: HOME x1, WAIT x log_wait_count, RUN x r, [END|ABORT] x log_end_count.
  */
 int Vehicle::log_state_at(size_t i) const {
     if (log_end_count > 0 && i >= log_size - (size_t)log_end_count) return state;
@@ -1117,6 +1119,11 @@ World::World(
       rng((std::mt19937::result_type)random_seed),
       flag_initialized(false),
       writer(&std::cout){
+    // The route update interval has a minimum of 1 timestep, like Python's DELTAT_ROUTE.
+    // Without the clamp, duo_update_time < delta_t would yield 0 and disable route updates entirely.
+    if (timestep_for_route_update == 0){
+        timestep_for_route_update = 1;
+    }
 }
 
 World::~World(){
@@ -1133,6 +1140,17 @@ World::~World(){
     nodes_map.clear();
     links_map.clear();
     vehicles_map.clear();
+}
+
+void World::set_t_max(double new_t_max){
+    t_max = new_t_max;
+    total_timesteps = (size_t)(t_max / delta_t);
+    for (auto ln : links){
+        ln->arrival_curve.resize(total_timesteps, 0.0);
+        ln->departure_curve.resize(total_timesteps, 0.0);
+        ln->traveltime_real.resize(total_timesteps, ln->length / ln->vmax);
+        ln->traveltime_instant.resize(total_timesteps, 0.0);
+    }
 }
 
 void World::initialize_adj_matrix(){
@@ -1154,8 +1172,8 @@ void World::initialize_adj_matrix(){
 
 void World::update_adj_time_matrix(){
     double noise = route_choice_uncertainty;
-    // Reset the cells written by links (running-average state). Matches Python's
-    // route_search_all, which rebuilds adj_mat_time from a zero matrix each call.
+    // Reset the cells written by links (running-average state).
+    // Matches Python's route_search_all, which rebuilds adj_mat_time from a zero matrix each call.
     if (adj_mat_link_count.size() != nodes.size()){
         adj_mat_link_count.assign(nodes.size(), vector<int>(nodes.size(), 0));
     }
@@ -1199,9 +1217,8 @@ void World::route_search_all(const vector<vector<double>> &adj, double infty) {
         infty = std::numeric_limits<double>::infinity();
     }
 
-    // Build adjacency list into reused scratch buffer. The `adj[i][j] > 0.0`
-    // edge filter is re-evaluated every call so the neighbour set/order is
-    // identical to the previous allocate-fresh implementation (bit-identical).
+    // Build adjacency list into reused scratch buffer.
+    // The `adj[i][j] > 0.0` edge filter is re-evaluated every call so the neighbour set/order is identical to the previous allocate-fresh implementation (bit-identical).
     rsa_adj_list.resize(nsize);
     for (int i = 0; i < nsize; i++) {
         auto &row = rsa_adj_list[i];
@@ -1275,9 +1292,8 @@ World::enumerate_k_random_routes_cpp(int k, unsigned int seed){
     int iteration = 0;
     double average_n_routes_old = 0;
 
-    // Weighted adjacency matrix, allocated once and reused. Every iteration
-    // overwrites exactly the same (i,j) link cells; non-link cells stay 0.0,
-    // so reuse is bit-identical to reallocating a zero-filled matrix each time.
+    // Weighted adjacency matrix, allocated once and reused.
+    // Every iteration overwrites exactly the same (i,j) link cells; non-link cells stay 0.0, so reuse is bit-identical to reallocating a zero-filled matrix each time.
     vector<vector<double>> adj(nsize, vector<double>(nsize, 0.0));
 
     while (true){
@@ -1361,8 +1377,8 @@ void World::route_choice_duo(){
     for (auto dest : nodes){
         int k = dest->id;
 
-        // psum==0.0 iff route_preference[k] has never been reinforced. Tracked
-        // incrementally via route_pref_active[k] to avoid an O(links) sum here.
+        // psum==0.0 iff route_preference[k] has never been reinforced.
+        // Tracked incrementally via route_pref_active[k] to avoid an O(links) sum here.
         auto duo_update_weight_tmp = duo_update_weight;
         if (!route_pref_active[k]){
             duo_update_weight_tmp = 1; //initialize with deterministic shortest path
@@ -1393,8 +1409,8 @@ void World::route_choice_duo_gradual(){
     for (auto dest : nodes){
         int k = dest->id;
 
-        // psum==0.0 iff route_preference[k] has never been reinforced (see
-        // route_choice_duo). Tracked via route_pref_active[k].
+        // psum==0.0 iff route_preference[k] has never been reinforced (see route_choice_duo).
+        // Tracked via route_pref_active[k].
         double w_tmp = weight0;
         if (!route_pref_active[k]){
             w_tmp = 1;
@@ -1477,8 +1493,7 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         return;
     }
 
-    // HOME/WAIT/RUN vehicles in id order; compacted in place each step to drop
-    // vehicles that reach END/ABORT (much faster when many have finished).
+    // HOME/WAIT/RUN vehicles in id order; compacted in place each step to drop vehicles that reach END/ABORT (much faster when many have finished).
     update_order.clear();
     for (auto veh : vehicles){
         if (veh->state <= vsRUN) update_order.push_back(veh);
@@ -1619,15 +1634,19 @@ inline void add_demand(
         double end_t,
         double flow,
         vector<string> links_preferred_str = {}){
+    // Iterate over integer timesteps, mirroring Python's adddemand: `for t in range(int(t_start/DELTAT), int(t_end/DELTAT))`.
+    // This keeps the iteration count and the timestep-quantized departure times identical to Python even when t_start/t_end are not multiples of delta_t.
+    int ts_start = (int)(start_t / w->delta_t);
+    int ts_end = (int)(end_t / w->delta_t);
     double demand = 0.0;
-    for (double t = start_t; t < end_t; t += w->delta_t){
+    for (int ts = ts_start; ts < ts_end; ts++){
         demand += flow * w->delta_t;
         while (demand >= (double)w->delta_n){
             // create new vehicle
             Vehicle *v = new Vehicle(
                 w,
                 std::to_string(w->vehicle_id),
-                t,
+                (double)ts * w->delta_t,
                 orig_name,
                 dest_name);
 
@@ -1642,8 +1661,7 @@ inline void add_demand(
 
 /**
  * @brief Return all vehicle states as (name, state_int) pairs.
- * Efficient bulk query so Python can update VEHICLES_LIVING/RUNNING
- * without calling state on each vehicle individually.
+ * Efficient bulk query so Python can update VEHICLES_LIVING/RUNNING without calling state on each vehicle individually.
  */
 std::vector<std::pair<std::string, int>> World::get_all_vehicle_states() const {
     std::vector<std::pair<std::string, int>> result;
@@ -1749,7 +1767,7 @@ World::CompactFlatLogs World::build_all_vehicle_logs_flat_compact() const {
             bool is_run = (st == vsRUN);
             fl.log_x[idx] = is_run ? v->log_x[i] : -1;
             fl.log_v[idx] = is_run ? v->log_v[i] : -1;
-            fl.log_s[idx] = is_run ? 0 : -1;
+            fl.log_s[idx] = v->log_s[i];
             fl.log_lane[idx] = v->log_lane[i];
             fl.log_link[idx] = v->log_link[i];
         }

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -127,10 +127,8 @@ struct Link {
 
     vector<double> arrival_curve;
     vector<double> departure_curve;
-    // traveltime_real is lazily materialized: link-exit events are buffered
-    // as (start_idx, travel_time) pairs and replayed into the array on first
-    // read via ensure_traveltime_real(). Members are mutable so that const
-    // read paths can trigger materialization.
+    // traveltime_real is lazily materialized: link-exit events are buffered as (start_idx, travel_time) pairs and replayed into the array on first read via ensure_traveltime_real().
+    // Members are mutable so that const read paths can trigger materialization.
     mutable vector<double> traveltime_real;
     mutable vector<pair<int, double>> traveltime_real_events;
     mutable size_t traveltime_real_events_applied;
@@ -235,14 +233,11 @@ struct Vehicle {
     vector<double> log_x;
     vector<double> log_v;
     vector<int> log_lane;
+    vector<double> log_s;  // spacing to leader on the same link (-1 if none)
     size_t log_size;  // current number of log entries (used instead of push_back)
 
-    // log_t / log_state are fully reconstructible from these scalars. The log
-    // structure is always HOME x1, WAIT x log_wait_count, RUN x r, [END|ABORT] x
-    // log_end_count, with one entry per timestep after departure; the only
-    // exception is trip end (the update() path records the END entry in the same
-    // timestep as the immediately preceding RUN entry, so log_last_ts may
-    // duplicate the previous timestep).
+    // log_t / log_state are fully reconstructible from these scalars.
+    // The log structure is always HOME x1, WAIT x log_wait_count, RUN x r, [END|ABORT] x log_end_count, with one entry per timestep after departure; the only exception is trip end (the update() path records the END entry in the same timestep as the immediately preceding RUN entry, so log_last_ts may duplicate the previous timestep).
     int log_first_ts;
     int log_last_ts;
     int log_wait_count;
@@ -332,8 +327,8 @@ struct World {
     vector<vector<double>> route_dist;
     map<int, vector<vector<double>>> route_dist_record;
 
-    // Scratch buffers reused across route_search_all() calls (avoid per-call
-    // V*V allocation). Filled by route_search_all; callers read from these.
+    // Scratch buffers reused across route_search_all() calls (avoid per-call V*V allocation).
+    // Filled by route_search_all; callers read from these.
     vector<vector<pair<int, double>>> rsa_adj_list;  // adjacency list (rebuilt each call)
     vector<vector<double>> rsa_dist;                 // all-pairs distances
     vector<vector<int>> rsa_next;                    // all-pairs next-hop
@@ -379,6 +374,10 @@ struct World {
     void initialize_adj_matrix();
     void update_adj_time_matrix();
 
+    // Update t_max/total_timesteps and resize per-link time-indexed arrays.
+    // Must be called before simulation start; the world may be created with a placeholder horizon before the final TMAX is known.
+    void set_t_max(double new_t_max);
+
     void route_choice_duo();
     void route_choice_duo_gradual();
 
@@ -410,8 +409,8 @@ struct World {
     // Useful for Python to update VEHICLES_LIVING/RUNNING without per-vehicle calls
     std::vector<std::pair<std::string, int>> get_all_vehicle_states() const;
 
-    // Build enter_log data: returns (link_id, time, vehicle_index) triples
-    // for all vehicle link-entry events. Used by _build_vehicles_enter_log.
+    // Build enter_log data: returns (link_id, time, vehicle_index) triples for all vehicle link-entry events.
+    // Used by _build_vehicles_enter_log.
     struct EnterLogEntry {
         int link_id;
         double time;

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -78,15 +78,29 @@ class CppNode:
         # Read back from C++ (single source of truth)
         self.x = self._cpp_node.x
         self.y = self._cpp_node.y
-        self.signal = list(self._cpp_node.signal_intervals)
         self.signal_offset = self._cpp_node.signal_offset
-        self.cycle_length = sum(self.signal)
         self.flow_capacity = self._cpp_node.flow_capacity
         self.number_of_lanes = self._cpp_node.number_of_lanes
         self.flag_lanes_automatically_determined = False
 
     def __repr__(self):
         return f"<Node {self.name}>"
+
+    @property
+    def signal(self):
+        return list(self._cpp_node.signal_intervals)
+    @signal.setter
+    def signal(self, value):
+        value = [float(x) for x in value]
+        self._cpp_node.signal_intervals = value
+        # If the current phase no longer exists in the new signal plan, reset it; Python mode raises IndexError in signal_control in this case.
+        if self._cpp_node.signal_phase >= len(value):
+            self._cpp_node.signal_phase = 0
+            self._cpp_node.signal_t = 0
+
+    @property
+    def cycle_length(self):
+        return sum(self.signal)
 
     @property
     def signal_phase(self):
@@ -180,8 +194,6 @@ class CppLink:
         self.merge_priority = cpp.merge_priority
         self.q_star = self.capacity
         self.k_star = self.capacity / self.u
-        self.capacity_out = cpp.capacity_out
-        self.capacity_in = cpp.capacity_in
         self._capacity_out_remain = cpp.capacity_out_remain
         self._capacity_in_remain = cpp.capacity_in_remain
 
@@ -261,6 +273,20 @@ class CppLink:
     @traveltime_actual.setter
     def traveltime_actual(self, value):
         self._traveltime_actual = value
+
+    @property
+    def capacity_out(self):
+        return self._cpp_link.capacity_out
+    @capacity_out.setter
+    def capacity_out(self, value):
+        self._cpp_link.capacity_out = float(value)
+
+    @property
+    def capacity_in(self):
+        return self._cpp_link.capacity_in
+    @capacity_in.setter
+    def capacity_in(self, value):
+        self._cpp_link.capacity_in = float(value)
 
     @property
     def capacity_in_remain(self):
@@ -401,8 +427,7 @@ class CppLink:
 
 
 class CppVehicle:
-    """Proxy wrapper around C++ Vehicle.  Reads most attributes directly from
-    C++ via __getattr__; only Python-only data lives on the Python object.
+    """Proxy wrapper around C++ Vehicle.  Reads most attributes directly from C++ via __getattr__; only Python-only data lives on the Python object.
     Instances are created via __new__ in _register_new_cpp_vehicles — no __init__."""
 
     # State int→str mapping
@@ -785,6 +810,7 @@ class CppWorld:
         self._skip_log_on_terminate = False
         self._skip_analyzer_setup = False
         self._cpp_veh_registered_count = 0
+        self._veh_by_index = []  # CppVehicle objects in C++ vehicle index order
 
     def _ensure_cpp_world(self):
         if self._cpp_world_created:
@@ -804,6 +830,7 @@ class CppWorld:
         self._cpp_world_created = True
         self._cpp_world.route_choice_update_gradual = self.route_choice_update_gradual
         self._cpp_world.no_cyclic_routing = self.no_cyclic_routing
+        self._cpp_world.instantaneous_TT_timestep_interval = int(self.instantaneous_TT_timestep_interval)
 
     # --- Scenario definition ---
 
@@ -846,17 +873,27 @@ class CppWorld:
         dep_is_ts = kwargs.get('departure_time_is_time_step', 0)
         t = departure_time * self.DELTAT if dep_is_ts else float(departure_time)
 
+        # Validate custom vehicle name before creating the C++ vehicle
+        name = kwargs.get('name')
+        if name is not None:
+            name = str(name)
+            if name in self.VEHICLES:
+                if kwargs.get('auto_rename', False):
+                    name = name + "_renamed" + "".join(
+                        self.rng.choice(list(string.ascii_letters + string.digits), size=8))
+                else:
+                    raise ValueError(f"Vehicle name {name} already used by another vehicle. Please specify a unique name.")
+
         # Resolve links_prefer to C++ link name strings
         links_prefer = kwargs.get('links_prefer', [])
         cpp_links_pref = []
         for l in links_prefer:
-            name = l.name if hasattr(l, 'name') else str(l)
-            cpp_links_pref.append(name)
+            lname = l.name if hasattr(l, 'name') else str(l)
+            cpp_links_pref.append(lname)
 
         n_before = self._cpp_world.vehicle_count
         _add_demand(self._cpp_world, orig_name, dest_name,
                    float(t), float(t + self.DELTAT), float(self.DELTAN / self.DELTAT), cpp_links_pref)
-        self._max_demand_t = max(getattr(self, '_max_demand_t', 0), t + self.DELTAT)
 
         # Set links_avoid on newly created C++ vehicles
         links_avoid = kwargs.get('links_avoid', [])
@@ -877,6 +914,19 @@ class CppWorld:
 
         self._register_new_cpp_vehicles()
 
+        veh = self._veh_by_index[n_before]
+        if name is not None:
+            # The new vehicle is the last entry, so pop+reinsert keeps VEHICLES in C++ index order.
+            self.VEHICLES.pop(veh.name, None)
+            self.VEHICLES_LIVING.pop(veh.name, None)
+            veh.name = name
+            self.VEHICLES[name] = veh
+            self.VEHICLES_LIVING[name] = veh
+        veh.attribute = kwargs.get('attribute')
+        veh.user_attribute = kwargs.get('user_attribute')
+        veh.user_function = kwargs.get('user_function')
+        return veh
+
     def _resolve_node_name(self, node):
         """Get node name string from Node object or string."""
         if hasattr(node, 'name'):
@@ -888,10 +938,13 @@ class CppWorld:
         self._ensure_cpp_world()
         if volume > 0:
             flow = volume / (t_end - t_start)
+        n_before = self._cpp_world.vehicle_count
         _add_demand(self._cpp_world, self._resolve_node_name(orig), self._resolve_node_name(dest),
                    float(t_start), float(t_end), float(flow), [])
-        self._max_demand_t = max(getattr(self, '_max_demand_t', 0), t_end)
         self._register_new_cpp_vehicles()
+        if attribute is not None:
+            for veh in self._veh_by_index[n_before:]:
+                veh.attribute = attribute
 
     @demand_info_record
     def adddemand_point2point(self, x_orig, y_orig, x_dest, y_dest, t_start, t_end, flow=-1, volume=-1, attribute=None, direct_call=True):
@@ -957,11 +1010,25 @@ class CppWorld:
 
     # --- Simulation ---
 
+    def _compute_auto_tmax(self):
+        """Determine TMAX from the latest vehicle departure time, matching Python's finalize_scenario."""
+        tmax = 0
+        for veh in self.VEHICLES.values():
+            dep = veh.departure_time * self.DELTAT
+            if dep > tmax:
+                tmax = dep
+        return (tmax // 1800 + 2) * 1800
+
     def finalize_scenario(self, tmax=None):
         """Initialize C++ world and prepare analyzer."""
         if self.TMAX is None:
-            self.TMAX = tmax if tmax else (getattr(self, '_max_demand_t', 0) // 1800 + 2) * 1800
+            if tmax is None:
+                self.TMAX = self._compute_auto_tmax()
+            else:
+                self.TMAX = tmax
         self._ensure_cpp_world()
+        # The C++ world may have been created before TMAX was known (with a placeholder horizon), so resize its time-indexed arrays to the final TMAX.
+        self._cpp_world.set_t_max(float(self.TMAX))
         self._cpp_world.initialize_adj_matrix()
         self._setup_analyzer()
 
@@ -976,8 +1043,7 @@ class CppWorld:
 
     def _setup_analyzer(self):
         """One-time setup of Python data structures required by analyzer.py.
-        This is NOT simulation logic — it initializes empty containers that
-        analyzer.py reads/writes during post-simulation analysis.
+        This is NOT simulation logic — it initializes empty containers that analyzer.py reads/writes during post-simulation analysis.
         TODO: Move these to C++ or analyzer.py to eliminate from wrapper.
         """
         self.T = 0
@@ -986,8 +1052,7 @@ class CppWorld:
 
         if self._skip_analyzer_setup:
             # Lightweight path for DTA intermediate iterations:
-            # Skip edie matrices (init_after_tmax_fix) and area containers
-            # that are only needed for visualization/compute_edie_state.
+            # Skip edie matrices (init_after_tmax_fix) and area containers that are only needed for visualization/compute_edie_state.
             # ADJ_MAT and Analyzer are still needed for basic_analysis/link_to_pandas.
             self.ADJ_MAT = np.zeros([len(self.NODES), len(self.NODES)])
             self.ADJ_MAT_LINKS = dict()
@@ -1023,22 +1088,32 @@ class CppWorld:
         if not self.finalized:
             self.finalize_scenario()
 
-        # Convert Python duration params to C++ until_t
+        # Determine the last timestep to execute (inclusive), following the same rules as Python's exec_simulation.
+        start_ts = self.T
         if until_t is not None:
-            cpp_until = until_t
+            end_ts = int(until_t / self.DELTAT)
         elif duration_t2 is not None:
-            cpp_until = self.TIME + duration_t2
+            end_ts = start_ts + int(duration_t2 / self.DELTAT) - 1
         elif duration_t is not None:
-            cpp_until = self.TIME + duration_t + self.DELTAT
+            end_ts = start_ts + int(duration_t / self.DELTAT)
         else:
-            cpp_until = self.TMAX
+            end_ts = self.TSIZE
+        if end_ts > self.TSIZE:
+            end_ts = self.TSIZE
 
-        self._cpp_world.main_loop(float(-1), float(cpp_until))
+        if start_ts == end_ts == self.TSIZE:
+            self.simulation_terminated()
+            return 1
+        if end_ts < start_ts:
+            raise Exception("exec_simulation error: Simulation duration is not positive. Check until_t or duration_t or duration_t2")
+
+        # C++ main_loop executes timesteps [current, floor(until_t/delta_t)]
+        self._cpp_world.main_loop(float(-1), float(end_ts * self.DELTAT))
         self._sync_from_cpp()
 
         # Update Python-side time tracking from C++ state
         self.T = self._cpp_world.timestep
-        self.TIME = self._cpp_world.time
+        self.TIME = self.T * self.DELTAT
 
         if self.T >= self.TSIZE:
             self.simulation_terminated()
@@ -1091,12 +1166,12 @@ class CppWorld:
             py_veh.link_old = None
             vehicles[name] = py_veh
             vehicles_living[name] = py_veh
+            self._veh_by_index.append(py_veh)
         self._cpp_veh_registered_count = total
 
     def _sync_from_cpp(self):
         """Update VEHICLES_LIVING / VEHICLES_RUNNING from C++ state.
-        Log caches are never explicitly invalidated — they start as None and are
-        built lazily on first access (e.g. when analyzer reads log_t)."""
+        Log caches are never explicitly invalidated — they start as None and are built lazily on first access (e.g. when analyzer reads log_t)."""
         # Batch-update VEHICLES_LIVING / VEHICLES_RUNNING using C++ bulk query
         try:
             states = self._cpp_world.get_all_vehicle_states()
@@ -1104,15 +1179,15 @@ class CppWorld:
             states = None
 
         if states is not None:
-            vehicles = self.VEHICLES
+            veh_by_index = self._veh_by_index
             living = self.VEHICLES_LIVING
             running = self.VEHICLES_RUNNING
-            # states is list of (cpp_name, state_int); Python names are sequential "0","1",...
+            # states[i] corresponds to the i-th created vehicle (C++ index order)
             for i, (_, st_int) in enumerate(states):
-                name = str(i)
-                veh = vehicles.get(name)
-                if veh is None:
+                if i >= len(veh_by_index):
                     continue
+                veh = veh_by_index[i]
+                name = veh.name
                 if st_int >= 3:  # end(3) or abort(4)
                     living.pop(name, None)
                     running.pop(name, None)
@@ -1136,6 +1211,15 @@ class CppWorld:
                     self.VEHICLES_LIVING[name] = veh
                     self.VEHICLES_RUNNING.pop(name, None)
 
+        # Expose on the analyzer the average speed statistic that Python mode accumulates in record_log.
+        # Waiting vehicles count as zero-speed samples, and the statistic is only available when vehicle logging is enabled, as in Python.
+        if self._cpp_vehicle_log_mode:
+            analyzer = getattr(self, 'analyzer', None)
+            if analyzer is not None:
+                cnt = self._cpp_world.stat_sample_count
+                analyzer.average_speed_count = int(cnt)
+                analyzer.average_speed = self._cpp_world.ave_v_sum / cnt if cnt > 0 else 0
+
     # --- Query methods ---
 
     def check_simulation_ongoing(self):
@@ -1158,7 +1242,7 @@ class CppWorld:
         all_ltl_id = flat['ltl_id']
         all_n_missing = flat.get('n_missing')
         delta_t = self.DELTAT
-        vehicles = list(self.VEHICLES.values())
+        vehicles = self._veh_by_index
         for i, veh in enumerate(vehicles):
             if veh._log_cache is not None:
                 continue
@@ -1217,7 +1301,7 @@ class CppWorld:
             veh_indices = data['vehicle_index']
             links_list = self.LINKS
             n_links = len(links_list)
-            vehicles_list = list(self.VEHICLES.values())
+            vehicles_list = self._veh_by_index
             for i in range(len(link_ids)):
                 lid = int(link_ids[i])
                 if 0 <= lid < n_links:


### PR DESCRIPTION
## Summary

This PR fixes 12 behavioral inconsistencies between `World(cpp=True)` and the Python core simulator, found by a line-by-line comparison of `uxsim.py` against the C++ engine (including edge cases), with each difference confirmed by paired-scenario experiments before fixing.

### Correctness fixes

1. **Auto-TMAX beyond the placeholder horizon** — With `tmax=None`, the C++ world is created before TMAX is known, using a 7200 s placeholder. Demand beyond 7200 s previously made the simulation stop early: `exec_simulation()` kept returning 0 and `check_simulation_ongoing()` stayed `True` forever (infinite-loop hazard for `while W.check_simulation_ongoing()`). A new `World::set_t_max()` resizes the per-link time-indexed arrays to the final TMAX at finalize.
2. **Auto-TMAX value** — TMAX is now derived from the latest vehicle departure time as in Python's `finalize_scenario` (previously derived from the demand end time, giving e.g. 5400 vs Python's 3600 when `t_end` is an exact multiple of 1800 s).
3. **`instantaneous_TT_timestep_interval` forwarding** — The parameter was never forwarded to C++, which always used the hardcoded default of 5, affecting route choice when a non-default interval is set.
4. **Route update interval clamp** — `duo_update_time < DELTAT` disabled route choice updates entirely in C++ (Python clamps `DELTAT_ROUTE` to 1); vehicles then routed uniformly at random. The C++ interval is now clamped to a minimum of 1 timestep.
5. **Demand/departure quantization** — `add_demand` now iterates integer timesteps exactly like Python's `adddemand`, so vehicle counts and timestep-quantized departure times match even when demand times are not multiples of DELTAT (previously off by one vehicle and one timestep in such cases).
6. **Partial execution timing** — `exec_simulation(duration_t=...)` and `duration_t2=...` executed one extra timestep per chunk, and `TIME` lagged `T*DELTAT` by one DELTAT after `until_t`. The wrapper now computes the last executed timestep exactly as Python does, raises the same exception on non-positive durations, and sets `TIME = T*DELTAT`.

### API compatibility fixes

7. **`addVehicle`** — now returns the Vehicle object (previously `None`) and supports the `name`/`auto_rename` (duplicate names raise `ValueError` as in Python), `attribute`, and `user_attribute` arguments; `adddemand` propagates `attribute` to the created vehicles.
8. **Mid-simulation `node.signal = [...]`** — the signal plan assignment is now forwarded to the engine (`signal_phase`/`signal_t` setters were already supported).
9. **Mid-simulation `link.capacity_out` / `link.capacity_in` assignment** — now forwarded to the engine.
10. **Route-choice edge case errors** — Python raises when `links_avoid` excludes all outgoing links (`ValueError`) or when an enforced route is inconsistent (`ValueError`) / exhausted (`IndexError`); C++ mode previously ignored the avoid-filter or silently stalled the vehicle. The engine now throws the corresponding exceptions (translated by nanobind to the same Python exception types).
11. **`Vehicle.log_s`** — now records the actual spacing to the leader on the same link (previously always 0 for running states).
12. **`analyzer.average_speed`** — now accumulated as in Python's `record_log` (waiting vehicles count as zero-speed samples); it was previously always 0 in C++ mode.

Intentionally not changed: shortest-path tie-breaking under `hard_deterministic_mode` (scipy vs the C++ Dijkstra may pick different but equally shortest paths) and `heterogeneous_DUO` (not implemented in the C++ engine).

## Tests

- Full C++ mode suite: **210 passed** (`pytest tests/test_cpp_mode.py --reruns 5`).
- Added 3 Python/C++ equivalence tests: auto-TMAX determination, auto-TMAX beyond the 7200 s placeholder horizon, and `W.T`/`W.TIME` agreement at every chunk boundary for `until_t`/`duration_t`/`duration_t2` (4 chunking patterns).
- Updated `test_coverage_addVehicle_taxi_and_links_avoid` to expect the Python-consistent `ValueError` (verified that Python mode raises `ValueError` in the same scenario).

## Validity check

9x9 grid, 288 links, 10,530 vehicles, boundary-to-boundary OD demand, 10 seeds, both modes:

- TTT: Python mean 6,082,682 (std 23,968) vs C++ mean 6,077,015 (std 19,437) — **0.09% mean difference**, max 0.82% per seed.
- Completed trips: identical (10,530) in all seeds.
- On deterministic scenarios (demand at DELTAT multiples, no route randomness), link cumulative curves are bit-identical between modes.

## Benchmark

Same scenario, `OMP_NUM_THREADS=1`, 10 seeds, total wall time (world construction + simulation + basic analysis):

- Python: median 2.079 s (std 0.278)
- C++: median 0.137 s (std 0.104)
- **Speedup: 15.2x**

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
