### PR TITLE
Add manually triggered PyPI publish workflow with trusted publishing

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -3,18 +3,114 @@ name: Publish to PyPI
 on:
   workflow_dispatch:
 
+concurrency:
+  group: publish-pypi
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  CIBUILDWHEEL_VERSION: "4.1.0"
+  UV_VERSION: "0.11.28"
+  CIBW_SKIP: "pp* *-musllinux*"
+  CIBW_BEFORE_BUILD: "pip install nanobind"
+  CIBW_ENVIRONMENT: "CMAKE_ARGS=''"
+  CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET='11.0'"
+  CIBW_TEST_REQUIRES: "pytest pytest-rerunfailures"
+  CIBW_TEST_COMMAND: "pytest {project}/tests/test_cpp_build.py -v"
+  CIBW_ARCHS_MACOS: "universal2"
+  CIBW_ARCHS_LINUX: "x86_64"
+  CIBW_ARCHS_WINDOWS: "AMD64"
+  CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+
 jobs:
-  build_and_publish:
-    name: Build and publish wheels
+  # Phase 1: build and test everything on all platforms, without publishing.
+  # This catches code-level failures before anything is uploaded to PyPI,
+  # so a partially published release can only be caused by infra-level flakiness.
+  test_build:
+    name: Test build wheels (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     permissions:
-      id-token: write
+      contents: read
     strategy:
+      fail-fast: false
       matrix:
         os: [windows-latest, ubuntu-latest, macos-latest]
 
     steps:
       - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel
+        run: |
+          pip install "cibuildwheel==${{ env.CIBUILDWHEEL_VERSION }}"
+
+      - name: Build and test wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+
+      - name: Verify wheel output
+        shell: bash
+        run: |
+          ls wheelhouse/*.whl
+
+  test_sdist:
+    name: Test build sdist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install uv
+        run: |
+          pip install "uv==${{ env.UV_VERSION }}"
+
+      - name: Build sdist
+        run: |
+          uv build --sdist --out-dir dist
+
+      - name: Smoke test sdist
+        run: |
+          sdist="$(ls dist/*.tar.gz)"
+          uv run --isolated --no-project --with "$sdist" python -c "import uxsim; print(uxsim.__version__)"
+
+  # Phase 2: rebuild the same commit and publish directly from each OS job.
+  # Runs only after phase 1 succeeded on all platforms, and is gated by the
+  # "pypi" environment (configure required reviewers for manual approval).
+  build_and_publish:
+    name: Build and publish (${{ matrix.os }})
+    needs: [test_build, test_sdist]
+    runs-on: ${{ matrix.os }}
+    environment:
+      name: pypi
+    permissions:
+      contents: read
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -23,22 +119,11 @@ jobs:
 
       - name: Install cibuildwheel and uv
         run: |
-          pip install cibuildwheel uv
+          pip install "cibuildwheel==${{ env.CIBUILDWHEEL_VERSION }}" "uv==${{ env.UV_VERSION }}"
 
       - name: Build wheels
         run: |
           python -m cibuildwheel --output-dir wheelhouse
-        env:
-          CIBW_SKIP: "pp* *-musllinux*"
-          CIBW_BEFORE_BUILD: "pip install nanobind"
-          CIBW_ENVIRONMENT: "CMAKE_ARGS=''"
-          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET='11.0'"
-          CIBW_TEST_REQUIRES: "pytest pytest-rerunfailures"
-          CIBW_TEST_COMMAND: "pytest {project}/tests/test_cpp_build.py -v"
-          CIBW_ARCHS_MACOS: "universal2"
-          CIBW_ARCHS_LINUX: "x86_64"
-          CIBW_ARCHS_WINDOWS: "AMD64"
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
 
       - name: Build sdist
         if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,0 +1,51 @@
+name: Publish to PyPI
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build_and_publish:
+    name: Build and publish wheels
+    runs-on: ${{ matrix.os }}
+    permissions:
+      id-token: write
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install cibuildwheel and uv
+        run: |
+          pip install cibuildwheel uv
+
+      - name: Build wheels
+        run: |
+          python -m cibuildwheel --output-dir wheelhouse
+        env:
+          CIBW_SKIP: "pp* *-musllinux*"
+          CIBW_BEFORE_BUILD: "pip install nanobind"
+          CIBW_ENVIRONMENT: "CMAKE_ARGS=''"
+          CIBW_ENVIRONMENT_MACOS: "MACOSX_DEPLOYMENT_TARGET='11.0'"
+          CIBW_TEST_REQUIRES: "pytest pytest-rerunfailures"
+          CIBW_TEST_COMMAND: "pytest {project}/tests/test_cpp_build.py -v"
+          CIBW_ARCHS_MACOS: "universal2"
+          CIBW_ARCHS_LINUX: "x86_64"
+          CIBW_ARCHS_WINDOWS: "AMD64"
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
+
+      - name: Build sdist
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          uv build --sdist --out-dir wheelhouse
+
+      - name: Publish to PyPI
+        shell: bash
+        run: |
+          uv publish --trusted-publishing always --check-url https://pypi.org/simple/uxsim/ wheelhouse/*


### PR DESCRIPTION
## Summary

Adds `.github/workflows/publish-to-pypi.yml`, a manually triggered (`workflow_dispatch`) workflow that builds wheels for all supported platforms and publishes them to PyPI using [trusted publishing](https://docs.pypi.org/trusted-publishers/) (OIDC) — no API token secrets required.

## Design

Two-phase structure to avoid partially published releases:

- **Phase 1 (`test_build` x 3 OS + `test_sdist`)**: builds and tests wheels with cibuildwheel on windows/ubuntu/macos (same configuration as the existing `build-wheels.yml`: CPython 3.10–3.14, universal2 on macOS, `tests/test_cpp_build.py` run against each wheel), and builds the sdist plus a smoke test installing it into an isolated environment. Nothing is uploaded in this phase, and jobs have `contents: read` only. Code-level failures are therefore caught before anything reaches PyPI.
- **Phase 2 (`build_and_publish` x 3 OS)**: starts only after all phase-1 jobs succeed (`needs:`), rebuilds the same commit, and each OS job uploads its own artifacts directly with `uv publish --trusted-publishing always`. The ubuntu job also uploads the sdist. This avoids relying on Actions artifact storage entirely.

If a phase-2 job fails for infra reasons, re-running the workflow completes the release: `--check-url` makes `uv publish` skip files already on PyPI, and the missing files are added to the same version.

## Security hardening

- `permissions: contents: read` explicit everywhere; `id-token: write` only on the publishing jobs
- Publishing jobs are gated by a GitHub environment `pypi`, so required reviewers can be enforced before anything is uploaded
- `persist-credentials: false` on all checkouts
- `concurrency` group prevents two publish runs in parallel
- cibuildwheel and uv are version-pinned

## Required one-time setup (repository owner)

1. **GitHub**: Settings → Environments → create environment `pypi` and add yourself as a required reviewer (this enables the manual approval gate before phase 2).
2. **PyPI**: on https://pypi.org/manage/project/uxsim/settings/publishing/ add a trusted publisher: Owner `toruseo`, Repository `UXsim`, Workflow `publish-to-pypi.yml`, Environment `pypi` (the environment name must match).

## Testing

- YAML validated; build configuration is identical to the existing `build-wheels.yml`, which passes on all three platforms
- No runtime code is touched (workflow file only), so simulator regression tests and benchmarks are not applicable

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)