### PR TITLE
Add Node.override_signal() support to C++ mode

### DIFF
--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -4315,6 +4315,79 @@ def test_4phase_signal_jpstyle():
         assert equal_tolerance(avt[i], referemce_avt[i])
 
 
+def test_override_signal():
+
+    # with initial setting
+    W = World(cpp=True,
+        name="",
+        deltan=1,
+        tmax=1200,
+        print_mode=1, save_mode=1, show_mode=1,
+        random_seed=0
+    )
+
+    # scenario
+    #merge network with signal
+    W.addNode("orig1", 0, 0)
+    W.addNode("orig2", 0, 2)
+    W.addNode("orig3", 0, 3)
+    W.addNode("dest", 2, 1)
+    W.addNode("merge", 1, 1, signal=[30,60]) #`signal` is a list of [duration of phase 0, duration of phase 1, ...]
+    W.addLink("link1", "orig1", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=1, signal_group=0) #if `signal_group` is 0, the exit of this link will be green at phase 0
+    W.addLink("link2", "orig2", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=1, signal_group=[0,1])
+    W.addLink("link2b", "orig3", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=0.5, signal_group=1)
+    W.addLink("link3", "merge", "dest", length=1000, free_flow_speed=20, jam_density=0.2, capacity_in=1)
+    W.adddemand("orig1", "dest", 0, 1000, 0.2)
+    W.adddemand("orig2", "dest", 500, 1000, 0.3)
+    W.adddemand("orig3", "dest", 500, 1000, 0.3)
+
+    # execute simulation
+    W.exec_simulation()
+
+    # visualize
+    W.analyzer.print_simple_stats()
+
+    ttt1 = W.analyzer.total_travel_time
+    cum1 = W.LINKS[0].cum_arrival
+
+    # with override
+    W = World(cpp=True,
+        name="",
+        deltan=1,
+        tmax=1200,
+        print_mode=1, save_mode=1, show_mode=1,
+        random_seed=0
+    )
+
+    # scenario
+    #merge network with signal
+    W.addNode("orig1", 0, 0)
+    W.addNode("orig2", 0, 2)
+    W.addNode("orig3", 0, 3)
+    W.addNode("dest", 2, 1)
+    merge = W.addNode("merge", 1, 1)
+    W.addLink("link1", "orig1", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=1)
+    W.addLink("link2", "orig2", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=1)
+    W.addLink("link2b", "orig3", "merge", length=1000, free_flow_speed=20, jam_density=0.2, merge_priority=0.5)
+    W.addLink("link3", "merge", "dest", length=1000, free_flow_speed=20, jam_density=0.2, capacity_in=1)
+    W.adddemand("orig1", "dest", 0, 1000, 0.2)
+    W.adddemand("orig2", "dest", 500, 1000, 0.3)
+    W.adddemand("orig3", "dest", 500, 1000, 0.3)
+
+    merge.override_signal(signal=[30,60], groups=[["link1", "link2"], ["link2", "link2b"]])
+
+    # execute simulation
+    W.exec_simulation()
+
+    # visualize
+    W.analyzer.print_simple_stats()
+
+    ttt2 = W.analyzer.total_travel_time
+    cum2 = W.LINKS[0].cum_arrival
+
+    assert ttt1 == ttt2
+    assert list(cum1) == list(cum2)  # list() for compatibility with cpp mode, where cum_arrival is a numpy array
+
 
 # ======================================================================
 # From test_wrapper_functions.py

--- a/tests/test_verification_node.py
+++ b/tests/test_verification_node.py
@@ -1129,4 +1129,4 @@ def test_override_signal():
     cum2 = W.LINKS[0].cum_arrival
 
     assert ttt1 == ttt2
-    assert cum1 == cum2
+    assert list(cum1) == list(cum2)  # list() for compatibility with cpp mode, where cum_arrival is a numpy array

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -123,6 +123,52 @@ class CppNode:
     def signal_log(self, value):
         self._cpp_node.signal_log = value
 
+    def override_signal(self, signal, groups=None, signal_offset=0, reset=False, signal_offset_old=None):
+        """
+        Override signal setting.
+
+        Parameters
+        ----------
+        signal : list of float
+            Duration of each signal phase in seconds.
+            For example, [30, 60] means that this signal has two phases; first is 30 sec green time for phase 0 and second is 60 sec green time for phase 1.
+        groups : list of list of str or Link
+            List of links that have green light for each signal phase.
+            For example, [[link1, link2], [link3, link4]] means that link1, link2 will have green in phase 0, and link3, link4 will have green light in phase 1.
+        signal_offset : float, optional
+            Offset of the signal cycle in seconds.
+        reset : bool, optional
+            If True, reset the current signal phase and elapsed phase time.
+        signal_offset_old : float, optional
+            Previous (wrong) signal offset in seconds. When specified, the new offset is calculated relative to the new cycle length. Kept for backward compatibility.
+        """
+        self.signal = signal
+        self.signal_offset = signal_offset
+        if reset:
+            self._cpp_node.signal_phase = 0
+            self._cpp_node.signal_t = 0
+        if signal_offset_old != None:
+            self.signal_offset = self.cycle_length - signal_offset_old
+        self._cpp_node.signal_offset = float(self.signal_offset)
+
+        if groups is None:
+            return None
+
+        if len(groups) != len(signal):
+            raise ValueError("The length of `group` must match the length of `signal`.")
+
+        phase_info = ddict(list)
+        for i, group in enumerate(groups):
+            for link in group:
+                l = self.W.get_link(link)
+                if l not in self.inlinks.values():
+                    raise ValueError(f"Link {l.name} is not an incoming link of node {self.name}.")
+                phase_info[l].append(i)
+
+        for key in phase_info:
+            key.signal_group = phase_info[key]
+            key._cpp_link.signal_group = phase_info[key]
+
 
 class CppLink:
     """Thin wrapper around C++ Link. Stores attributes for analyzer compatibility."""


### PR DESCRIPTION
## Summary

Ports `Node.override_signal()` (added for Python mode in #338) to the C++ engine mode (`World(cpp=True)`).

- Implements `CppNode.override_signal()` in `uxsim/uxsim_cpp_wrapper.py` as a line-by-line port of the Python implementation, with identical signature, semantics, and error messages (ValueError on group/signal length mismatch and on non-incoming links).
- No C++ core change is needed: `Node.signal_intervals`/`signal_phase`/`signal_t`/`signal_offset` and `Link.signal_group` are already exposed as read-write bindings and are read directly by the simulation loop, so the wrapper syncs the overridden state into the C++ engine.
- Adds `test_override_signal` to `tests/test_cpp_mode.py` (cpp-mode copy of the new Python test).
- Changes one assertion in `tests/test_verification_node.py::test_override_signal` from `cum1 == cum2` to `list(cum1) == list(cum2)`: `Link.cum_arrival` is a numpy array in cpp mode, so the original list comparison raises ValueError under `pytest --cpp`. With this change the test passes in both modes; behavior in pure-Python mode is unchanged.

## Tests

- `pytest tests/test_cpp_mode.py`: **211 passed** (including the new test; 9 flaky reruns succeeded)
- `pytest tests/test_verification_node.py`: passed both without and with `--cpp`

## Validity check (Python vs C++)

Merge network scenario from the new test, extended to `tmax=3600`, `deltan=1`, 3 seeds. Signals set either at `addNode` or via `override_signal` with equivalent groups:

- Python vs C++ total travel time difference: 0.49–4.06 % (due to different random number streams; within usual tolerance)
- Within each mode, initial-setting vs `override_signal` results are **exactly identical** (TTT and cumulative curves), in both Python and C++ modes

## Benchmark

Signalized 8x8 grid (64 nodes, 224 links, two-phase signals configured via `override_signal`, `deltan=5`, `tmax=3600`), `OMP_NUM_THREADS=1`, 10 seeds, median±std of `exec_simulation` wall time:

| Mode | median | std |
|------|--------|-----|
| Python | 22.670 s | 1.076 s |
| C++ | 0.719 s | 0.108 s |

**Speedup: 31.5x**. TTT medians differ by +13.8 %, which is not statistically significant (Welch t-test p=0.45) given the large seed-to-seed variation of this congested scenario; the feature-level validity check above confirms agreement within a few percent.

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)