### PR TITLE
Refactor C++ engine to a data-oriented SoA core with deterministic OpenMP parallelization

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(nanobind CONFIG REQUIRED)
 
+# OpenMP for the deterministic parallel main-loop stages. Not REQUIRED: when it is
+# unavailable the `#pragma omp` directives are ignored and the engine runs serially
+# (the code calls no omp_* runtime functions, only pragmas), so the build still succeeds.
+find_package(OpenMP)
+
 # Python extension module
 # bindings.cpp includes traffi.cpp directly via #include
 nanobind_add_module(uxsim_cpp
@@ -24,6 +29,11 @@ if(MSVC)
     target_compile_options(uxsim_cpp PRIVATE /O2)
 else()
     target_compile_options(uxsim_cpp PRIVATE -O3)
+endif()
+
+# Link OpenMP when available (enables the parallel main-loop stages).
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(uxsim_cpp PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 # Coverage flags (enabled via -DCOVERAGE=ON)

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8713,3 +8713,52 @@ def test_exec_simulation_partial_run_python_cpp_equivalence():
         Wcpp.analyzer.basic_analysis()
         assert eq_tol(Wpy.analyzer.total_travel_time, Wcpp.analyzer.total_travel_time, rel_tol=0.02)
         assert Wpy.analyzer.trip_completed == Wcpp.analyzer.trip_completed
+
+
+def test_threads_parameter():
+    """C++-mode `threads` argument: results must be bit-identical across thread counts, and invalid values must raise ValueError.
+
+    The same seeded grid scenario (route choice active, so the parallel route_search / route_choice / main-loop regions are exercised) is run with threads=1, threads=2 and threads=-1 (all cores). Every vehicle's log_t/log_x/log_v and the total travel time must be exactly equal, confirming the num_threads() clauses preserve determinism regardless of thread count.
+    """
+    def build_and_run(threads):
+        W = World(name="", deltan=5, tmax=1500, print_mode=0, save_mode=0, show_mode=0,
+                  random_seed=42, no_cyclic_routing=True, cpp=True, threads=threads)
+        imax = jmax = 5
+        nodes = {}
+        for i in range(imax):
+            for j in range(jmax):
+                nodes[i, j] = W.addNode(f"n{(i, j)}", i, j)
+        for i in range(imax):
+            for j in range(jmax):
+                if i != imax - 1:
+                    W.addLink(f"l{(i, j, i+1, j)}", nodes[i, j], nodes[i+1, j], length=1000, free_flow_speed=20, jam_density=0.2)
+                if i != 0:
+                    W.addLink(f"l{(i, j, i-1, j)}", nodes[i, j], nodes[i-1, j], length=1000, free_flow_speed=20, jam_density=0.2)
+                if j != jmax - 1:
+                    W.addLink(f"l{(i, j, i, j+1)}", nodes[i, j], nodes[i, j+1], length=1000, free_flow_speed=20, jam_density=0.2)
+                if j != 0:
+                    W.addLink(f"l{(i, j, i, j-1)}", nodes[i, j], nodes[i, j-1], length=1000, free_flow_speed=20, jam_density=0.2)
+        for j in range(jmax):
+            W.adddemand(nodes[0, j], nodes[imax - 1, jmax - 1 - j], 0, 1000, 0.3)
+            W.adddemand(nodes[imax - 1, j], nodes[0, jmax - 1 - j], 0, 1000, 0.3)
+        W.exec_simulation()
+        W.analyzer.basic_analysis()
+        logs = {}
+        for name, veh in W.VEHICLES.items():
+            logs[name] = (list(veh.log_t), list(veh.log_x), list(veh.log_v))
+        return logs, W.analyzer.total_travel_time
+
+    logs1, ttt1 = build_and_run(1)
+    logs2, ttt2 = build_and_run(2)
+    logsN, tttN = build_and_run(-1)
+
+    assert logs1.keys() == logs2.keys() == logsN.keys()
+    for name in logs1:
+        for other in (logs2, logsN):
+            for a, b in zip(logs1[name], other[name]):
+                assert (np.asarray(a) == np.asarray(b)).all(), f"vehicle {name} log mismatch across thread counts"
+    assert ttt1 == ttt2 == tttN
+
+    for bad in (0, -2):
+        with pytest.raises(ValueError):
+            World(name="", tmax=100, print_mode=0, save_mode=0, show_mode=0, cpp=True, threads=bad)

--- a/uxsim/trafficpp/CMakeLists.txt
+++ b/uxsim/trafficpp/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(nanobind CONFIG REQUIRED)
 
+# OpenMP for the deterministic parallel main-loop stages. Not REQUIRED: when it is
+# unavailable the `#pragma omp` directives are ignored and the engine runs serially
+# (the code calls no omp_* runtime functions, only pragmas), so the build still succeeds.
+find_package(OpenMP)
+
 # Python extension module
 # Note: bindings.cpp includes traffi.cpp directly via #include "traffi.cpp",
 # so we only compile bindings.cpp as the single translation unit.
@@ -25,6 +30,11 @@ if(MSVC)
     target_compile_options(uxsim_cpp PRIVATE /O2)
 else()
     target_compile_options(uxsim_cpp PRIVATE -O3)
+endif()
+
+# Link OpenMP when available (enables the parallel main-loop stages).
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(uxsim_cpp PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 # Static linking for MinGW

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -542,6 +542,7 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("route_choice_update_gradual", &World::route_choice_update_gradual)
         .def_rw("no_cyclic_routing", &World::no_cyclic_routing)
         .def_rw("instantaneous_TT_timestep_interval", &World::instantaneous_TT_timestep_interval)
+        .def_rw("num_threads", &World::num_threads)
         .def_ro("route_dist", &World::route_dist)
         .def_ro("route_dist_record", &World::route_dist_record)
         .def_ro("route_next", &World::route_next)

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -802,14 +802,16 @@ NB_MODULE(uxsim_cpp, m) {
         .def("change_jam_density", &Link::change_jam_density, nb::arg("new_value"))
         .def("count_vehicles_in_queue", &Link::count_vehicles_in_queue)
         .def_prop_ro("vehicle_count", [](const Link &l) -> size_t {
-                 return l.vehicles.size();
+                 return (size_t)l.q_size();
              },
              "Number of vehicles on this link (O(1), no list conversion)")
         .def_prop_ro("avg_speed", [](const Link &l) -> double {
-                 if (l.vehicles.empty()) return l.vmax;
+                 if (l.q_empty()) return l.vmax;
                  double sum = 0;
-                 for (auto *v : l.vehicles) sum += v->v();
-                 return sum / l.vehicles.size();
+                 for (long long s = l.veh_head_seq; s < l.veh_tail_seq; s++){
+                     sum += l.w->veh_v[l.veh_ring[s & l.veh_ring_mask]];
+                 }
+                 return sum / l.q_size();
              },
              "Average speed of vehicles on this link (computed in C++)")
         // Numpy array accessors — avoid list() conversion overhead on Python side
@@ -853,8 +855,8 @@ NB_MODULE(uxsim_cpp, m) {
         .def_prop_ro("x_next", [](const Vehicle &v) { return v.x_next(); })
         .def_prop_ro("v", [](const Vehicle &v) { return v.v(); })
         .def_prop_ro("lane", [](const Vehicle &v) { return v.lane(); })
-        .def_ro("leader", &Vehicle::leader)
-        .def_ro("follower", &Vehicle::follower)
+        .def_prop_ro("leader", [](const Vehicle &v) { return v.leader(); })
+        .def_prop_ro("follower", [](const Vehicle &v) { return v.follower(); })
         .def_prop_rw("state", [](const Vehicle &v) { return v.state(); }, [](Vehicle &v, int val) { v.state() = val; })
         .def_ro("arrival_time_link", &Vehicle::arrival_time_link)
         .def_rw("route_next_link", &Vehicle::route_next_link)

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -862,7 +862,14 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("route_next_link", &Vehicle::route_next_link)
         .def_rw("route_choice_flag_on_link", &Vehicle::route_choice_flag_on_link)
         .def_rw("route_adaptive", &Vehicle::route_adaptive)
-        .def_rw("route_preference", &Vehicle::route_preference)
+        // route_preference is stored lazily (empty until written): the getter returns
+        // links.size() zeros when empty, matching the old eager per-vehicle vector.
+        .def_prop_rw("route_preference",
+            [](const Vehicle &v) -> vector<double> {
+                if (v.route_preference.empty()) return vector<double>(v.w->links.size(), 0.0);
+                return v.route_preference;
+            },
+            [](Vehicle &v, vector<double> val) { v.route_preference = std::move(val); })
         .def_rw("links_preferred", &Vehicle::links_preferred)
         .def_rw("links_avoid", &Vehicle::links_avoid)
         .def_rw("specified_route", &Vehicle::specified_route)

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -550,8 +550,8 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("vehicle_log_mode", &World::vehicle_log_mode)
         .def_ro("ave_v", &World::ave_v)
         .def_ro("ave_vratio", &World::ave_vratio)
-        .def_ro("ave_v_sum", &World::ave_v_sum)
-        .def_ro("stat_sample_count", &World::stat_sample_count)
+        .def_prop_ro("ave_v_sum", [](const World &w) { return w.ave_v_sum(); })
+        .def_prop_ro("stat_sample_count", [](const World &w) { return w.stat_sample_count(); })
         .def("set_t_max", &World::set_t_max,
              nb::arg("new_t_max"),
              "Update t_max/total_timesteps and resize per-link time-indexed arrays (call before simulation start)")

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -808,7 +808,7 @@ NB_MODULE(uxsim_cpp, m) {
         .def_prop_ro("avg_speed", [](const Link &l) -> double {
                  if (l.vehicles.empty()) return l.vmax;
                  double sum = 0;
-                 for (auto *v : l.vehicles) sum += v->v;
+                 for (auto *v : l.vehicles) sum += v->v();
                  return sum / l.vehicles.size();
              },
              "Average speed of vehicles on this link (computed in C++)")
@@ -848,14 +848,14 @@ NB_MODULE(uxsim_cpp, m) {
         .def_ro("departure_time", &Vehicle::departure_time)
         .def_rw("orig", &Vehicle::orig)
         .def_rw("dest", &Vehicle::dest)
-        .def_ro("link", &Vehicle::link)
-        .def_ro("x", &Vehicle::x)
-        .def_ro("x_next", &Vehicle::x_next)
-        .def_ro("v", &Vehicle::v)
-        .def_ro("lane", &Vehicle::lane)
+        .def_prop_ro("link", [](const Vehicle &v) { return v.link(); })
+        .def_prop_ro("x", [](const Vehicle &v) { return v.x(); })
+        .def_prop_ro("x_next", [](const Vehicle &v) { return v.x_next(); })
+        .def_prop_ro("v", [](const Vehicle &v) { return v.v(); })
+        .def_prop_ro("lane", [](const Vehicle &v) { return v.lane(); })
         .def_ro("leader", &Vehicle::leader)
         .def_ro("follower", &Vehicle::follower)
-        .def_rw("state", &Vehicle::state)
+        .def_prop_rw("state", [](const Vehicle &v) { return v.state(); }, [](Vehicle &v, int val) { v.state() = val; })
         .def_ro("arrival_time_link", &Vehicle::arrival_time_link)
         .def_rw("route_next_link", &Vehicle::route_next_link)
         .def_rw("route_choice_flag_on_link", &Vehicle::route_choice_flag_on_link)
@@ -865,8 +865,8 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("links_avoid", &Vehicle::links_avoid)
         .def_rw("specified_route", &Vehicle::specified_route)
         .def("enforce_route", &Vehicle::enforce_route, nb::arg("route"))
-        .def_rw("move_remain", &Vehicle::move_remain)
-        .def_ro("x_old", &Vehicle::x_old)
+        .def_prop_rw("move_remain", [](const Vehicle &v) { return v.move_remain(); }, [](Vehicle &v, double val) { v.move_remain() = val; })
+        .def_prop_ro("x_old", [](const Vehicle &v) { return v.x_old(); })
         .def_rw("trip_abort", &Vehicle::trip_abort)
         .def_ro("flag_trip_aborted", &Vehicle::flag_trip_aborted)
         .def_ro("flag_waiting_for_trip_end", &Vehicle::flag_waiting_for_trip_end)

--- a/uxsim/trafficpp/dta_solver.cpp
+++ b/uxsim/trafficpp/dta_solver.cpp
@@ -47,7 +47,7 @@ TraveledRouteInfo dta_get_traveled_route(const Vehicle *veh) {
         }
     }
 
-    if (veh->state == vsEND && veh->arrival_time >= 0){
+    if (veh->state() == vsEND && veh->arrival_time >= 0){
         info.arrival_time = veh->arrival_time;
     }
     return info;
@@ -165,7 +165,7 @@ RouteSwapResult dta_route_swap_due(
         }
 
         // Skip vehicles that didn't finish their trip (leave empty = no enforce_route)
-        if (veh->state != vsEND){
+        if (veh->state() != vsEND){
             continue;
         }
 
@@ -305,7 +305,7 @@ RouteSwapResult dta_route_swap_dso(
         }
 
         // Skip vehicles that didn't finish their trip (leave empty = no enforce_route)
-        if (veh->state != vsEND){
+        if (veh->state() != vsEND){
             continue;
         }
 

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -197,6 +197,36 @@ void Node::flow_capacity_update(){
  * @brief Transfer vehicles between links at the node.
  */
 void Node::transfer(){
+    // Canonicalize incoming order to vehicle idx (== id) ascending. The fused RUN pass
+    // registers arriving vehicles in link/queue order rather than id order; restoring id
+    // order here keeps the hard_deterministic tie-break and RNG-independent scenarios
+    // bit-identical to the original id-ordered update loop. requests stays parallel.
+    {
+        size_t n = incoming_vehicles.size();
+        if (n > 1){
+            bool sorted = true;
+            for (size_t i = 1; i < n; i++){
+                if (incoming_vehicles[i - 1]->idx > incoming_vehicles[i]->idx){ sorted = false; break; }
+            }
+            if (!sorted){
+                vector<int> order(n);
+                for (size_t i = 0; i < n; i++) order[i] = (int)i;
+                std::sort(order.begin(), order.end(), [&](int a, int b){
+                    return incoming_vehicles[a]->idx < incoming_vehicles[b]->idx;
+                });
+                vector<Vehicle *> sv(n);
+                vector<Link *> sr(incoming_vehicles_requests.size());
+                bool has_req = incoming_vehicles_requests.size() == n;
+                for (size_t i = 0; i < n; i++){
+                    sv[i] = incoming_vehicles[order[i]];
+                    if (has_req) sr[i] = incoming_vehicles_requests[order[i]];
+                }
+                incoming_vehicles.swap(sv);
+                if (has_req) incoming_vehicles_requests.swap(sr);
+            }
+        }
+    }
+
     // Build outlink list with repetition per lane (multi-lane gets more transfer attempts)
     _buf_outlinks_expanded.clear();
     _buf_seen_outlinks.clear();
@@ -740,58 +770,6 @@ Vehicle::Vehicle(
 }
 
 /**
- * @brief Update vehicle state and movement.
- */
-void Vehicle::update(){
-
-    if (state() == vsHOME){
-        if ((double)w->timestep * w->delta_t >= departure_time){
-            log_data();
-            state() = vsWAIT;
-            orig->generation_queue.push_back(this);
-        }
-    }else if (state() == vsWAIT){
-        log_data();
-    }else if (state() == vsRUN){
-        log_data();
-        if (x() == 0.0){
-            route_choice_flag_on_link = 0;
-        }
-
-        v() = (x_next() - x()) / (w->delta_t);
-        x_old() = x();
-        x() = x_next();
-
-        distance_traveled += x() - x_old();
-
-        Link *lk = link();
-        if (std::fabs(x() - lk->length) < 1e-9){
-            if (lk->end_node == dest){
-                // Prepare for trip end (wait if not at front of link)
-                flag_waiting_for_trip_end = 1;
-                if (w->vehicles[lk->q_front_idx()] == this){
-                    end_trip();
-                }
-            }else if (lk->end_node->out_links.empty() && trip_abort == 1){
-                // Dead-end: abort trip
-                flag_trip_aborted = 1;
-                route_next_link = nullptr;
-                flag_waiting_for_trip_end = 1;
-                if (w->vehicles[lk->q_front_idx()] == this){
-                    end_trip();
-                }
-            }else{
-                route_next_link_choice(lk->end_node->out_links);
-                lk->end_node->incoming_vehicles.push_back(this);
-                lk->end_node->incoming_vehicles_requests.push_back(route_next_link);
-            }
-        }
-    }else if (state() == vsEND || state() == vsABORT){
-        // do nothing
-    }
-}
-
-/**
  * @brief End the vehicle's trip.
  */
 void Vehicle::end_trip(){
@@ -832,38 +810,6 @@ void Vehicle::end_trip(){
 
     // Final log entry
     log_data();
-}
-
-/**
- * @brief Apply Newell's car-following model.
- */
-void Vehicle::car_follow_newell(){
-    Link *lk = link();
-    // free-flow
-    x_next() = x() + lk->vmax * w->delta_t;
-
-    // congested (use delta_per_lane for multi-lane car following)
-    Vehicle *ld = leader();
-    if (ld != nullptr){
-        double gap = ld->x() - lk->delta_per_lane * w->delta_n;
-        if (gap < x()){
-            gap = x();
-        }
-        if (x_next() > gap){
-            x_next() = gap;
-        }
-    }
-
-    // non-decreasing
-    if (x_next() < x()){
-        x_next() = x();
-    }
-
-    // clamp to link length, carry over residual as move_remain
-    if (x_next() > lk->length){
-        move_remain() = x_next() - lk->length;
-        x_next() = lk->length;
-    }
 }
 
 /**
@@ -1032,6 +978,33 @@ void Vehicle::log_data(){
             log_lane.push_back(-1);
             log_s.push_back(-1.0);
         }
+        log_size++;
+    }
+}
+
+/**
+ * @brief Log a RUN-state vehicle with a caller-supplied leader spacing.
+ * The fused RUN system pass processes links front-to-back and derives the leader
+ * spacing from the ring buffer directly (the generic log_data() leader() accessor
+ * would read the leader's post-move position unconditionally, which does not
+ * reproduce the id-ordered read semantics of the original update() loop).
+ */
+void Vehicle::log_data_run(double spacing){
+    Link *lk = link();
+    w->ave_v_sum += v();
+    if (lk){
+        w->ave_vratio_sum += v() / lk->vmax;
+    }
+    w->stat_sample_count += 1.0;
+
+    if (w->vehicle_log_mode){
+        if (log_size == 0) log_first_ts = (int)w->timestep;
+        log_last_ts = (int)w->timestep;
+        log_link.push_back(lk ? lk->id : -1);
+        log_x.push_back(x());
+        log_v.push_back(v());
+        log_lane.push_back(lane());
+        log_s.push_back(spacing);
         log_size++;
     }
 }
@@ -1536,10 +1509,19 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         return;
     }
 
-    // HOME/WAIT/RUN vehicles in id order; compacted in place each step to drop vehicles that reach END/ABORT (much faster when many have finished).
-    update_order.clear();
+    // Rebuild HOME departure buckets: bucket[ts] holds the idx (id ascending, since
+    // `vehicles` is in id order) of HOME vehicles whose first departing timestep is ts.
+    // ts0 is the smallest timestep with (double)ts0*delta_t >= departure_time, using the
+    // exact same FP comparison as the original per-step HOME predicate, then clamped to
+    // the chunk start (past-due vehicles depart on the first step of the chunk).
+    departure_buckets.assign(total_timesteps, {});
     for (auto veh : vehicles){
-        if (veh->state() <= vsRUN) update_order.push_back(veh);
+        if (veh->state() == vsHOME){
+            int ts0 = (int)(veh->departure_time / delta_t);
+            while ((double)ts0 * delta_t < veh->departure_time) ts0++;
+            if (ts0 < start_ts) ts0 = start_ts;
+            if (ts0 < (int)total_timesteps) departure_buckets[ts0].push_back(veh->idx);
+        }
     }
 
     for (timestep = start_ts; timestep < end_ts; timestep++){
@@ -1568,25 +1550,112 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             nd->transfer();
         }
 
-        // car-following (update_order is in id order, so hard_deterministic semantics hold)
-        for (auto veh : update_order){
-            if (veh->state() == vsRUN){
-                veh->car_follow_newell();
+        // RUN system pass: fuse the old car_follow + update(RUN) into a single link-ordered
+        // sweep. Each link is processed front-to-back over a head/tail snapshot so leaders
+        // (ahead in the queue) are moved before their followers, matching the old two-phase
+        // (car_follow-all then update-all) reads via x_old.
+        for (auto lk : links){
+            long long head0 = lk->veh_head_seq;
+            long long tail0 = lk->veh_tail_seq;
+            int lanes = lk->number_of_lanes;
+            int mask = lk->veh_ring_mask;
+            double dpl_dn = lk->delta_per_lane * delta_n;
+            double vmax_dt = lk->vmax * delta_t;
+            double length = lk->length;
+            for (long long s = head0; s < tail0; s++){
+                int vi = lk->veh_ring[s & mask];
+                Vehicle *veh = vehicles[vi];
+
+                // Leader derived from the pre-pass queue snapshot (head0), so a leader that
+                // end_trip()'d earlier in this pass is still readable from its ring slot.
+                long long seq_leader = s - lanes;
+                int leader_vi = (seq_leader >= head0) ? lk->veh_ring[seq_leader & mask] : -1;
+
+                // car_follow (Newell): self uses its current x, the leader uses x_old
+                // (its pre-move position this step, already stored since the leader moved
+                // first in this front-to-back sweep).
+                double self_x = veh_x[vi];
+                double xn = self_x + vmax_dt;
+                if (leader_vi >= 0){
+                    double gap = veh_x_old[leader_vi] - dpl_dn;
+                    if (gap < self_x) gap = self_x;
+                    if (xn > gap) xn = gap;
+                }
+                if (xn < self_x) xn = self_x;
+                if (xn > length){
+                    veh_move_remain[vi] = xn - length;
+                    xn = length;
+                }
+                veh_x_next[vi] = xn;
+
+                // log_data (RUN): spacing to the leader reproduces the id-ordered read of the
+                // original update() loop. A lower-id leader was updated before self, so self
+                // saw its post-move x (or, if it end_trip()'d, no leader -> -1); a higher-id
+                // leader had not moved when self logged, so self saw its pre-move x (x_old).
+                double spacing = -1.0;
+                if (leader_vi >= 0){
+                    Vehicle *ld = vehicles[leader_vi];
+                    if (ld->id < veh->id){
+                        int lst = veh_state[leader_vi];
+                        if (lst != vsEND && lst != vsABORT){
+                            spacing = veh_x[leader_vi] - self_x;
+                        }
+                    } else {
+                        spacing = veh_x_old[leader_vi] - self_x;
+                    }
+                }
+                veh->log_data_run(spacing);
+
+                // move + link-end handling (identical to the old update() RUN branch)
+                if (self_x == 0.0){
+                    veh->route_choice_flag_on_link = 0;
+                }
+                veh_v[vi] = (xn - self_x) / delta_t;
+                veh_x_old[vi] = self_x;
+                veh_x[vi] = xn;
+                veh->distance_traveled += xn - self_x;
+
+                if (std::fabs(xn - length) < 1e-9){
+                    if (lk->end_node == veh->dest){
+                        veh->flag_waiting_for_trip_end = 1;
+                        if (vehicles[lk->q_front_idx()] == veh){
+                            veh->end_trip();
+                        }
+                    } else if (lk->end_node->out_links.empty() && veh->trip_abort == 1){
+                        veh->flag_trip_aborted = 1;
+                        veh->route_next_link = nullptr;
+                        veh->flag_waiting_for_trip_end = 1;
+                        if (vehicles[lk->q_front_idx()] == veh){
+                            veh->end_trip();
+                        }
+                    } else {
+                        veh->route_next_link_choice(lk->end_node->out_links);
+                        lk->end_node->incoming_vehicles.push_back(veh);
+                        lk->end_node->incoming_vehicles_requests.push_back(veh->route_next_link);
+                    }
+                }
             }
         }
 
-        // vehicle update, compacting update_order in place (drops END/ABORT vehicles)
-        size_t wpos = 0;
-        for (size_t r = 0; r < update_order.size(); r++){
-            Vehicle *veh = update_order[r];
-            if (veh->state() <= vsRUN){
-                veh->update();
-            }
-            if (veh->state() <= vsRUN){
-                update_order[wpos++] = veh;
+        // WAIT system pass: vehicles still in a generation_queue (those not generated this
+        // step) log a WAIT entry. Vehicles departing this step are logged as HOME below and
+        // enter the queue only afterwards, so they are not double-logged here.
+        for (auto nd : nodes){
+            for (auto veh : nd->generation_queue){
+                veh->log_data();
             }
         }
-        update_order.resize(wpos);
+
+        // HOME departure pass: vehicles whose departure timestep is now log a HOME entry,
+        // transition to WAIT, and enter their origin generation_queue (id ascending).
+        if (timestep < total_timesteps){
+            for (int vi : departure_buckets[timestep]){
+                Vehicle *veh = vehicles[vi];
+                veh->log_data();
+                veh->state() = vsWAIT;
+                veh->orig->generation_queue.push_back(veh);
+            }
+        }
 
         // route choice update
         if (route_choice_update_gradual){

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -15,6 +15,10 @@
 #include <climits>
 #include <exception>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "traffi.h"
 
 using std::string, std::vector, std::deque, std::pair, std::map, std::unordered_map;
@@ -1241,6 +1245,15 @@ void World::update_adj_time_matrix(){
     }
 }
 
+int World::resolve_num_threads() const {
+#ifdef _OPENMP
+    if (num_threads == -1) return omp_get_max_threads();
+    return num_threads;
+#else
+    return 1;
+#endif
+}
+
 void World::route_search_all(const vector<vector<double>> &adj, double infty) {
     int nsize = (int)adj.size();
     if (std::fabs(infty) < 1e-9) {
@@ -1275,7 +1288,7 @@ void World::route_search_all(const vector<vector<double>> &adj, double infty) {
     // rsa_next[start] rows, and rsa_adj_list is read-only here, so the source loop is
     // parallel-safe with per-thread visited flags and priority queue (the shared scratch is
     // thread-local). The result is independent of thread count.
-    #pragma omp parallel
+    #pragma omp parallel num_threads(resolve_num_threads())
     {
         vector<char> visited(nsize);
         std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
@@ -1415,7 +1428,7 @@ void World::route_choice_duo(){
     // route_next and links are read-only here, so the destination loop is parallel-safe and
     // independent of thread count.
     int nnodes = (int)nodes.size();
-    #pragma omp parallel for schedule(static)
+    #pragma omp parallel for schedule(static) num_threads(resolve_num_threads())
     for (int di = 0; di < nnodes; di++){
         Node *dest = nodes[di];
         int k = dest->id;
@@ -1451,7 +1464,7 @@ void World::route_choice_duo_gradual(){
 
     // Per-destination and thread-count independent (see route_choice_duo).
     int nnodes = (int)nodes.size();
-    #pragma omp parallel for schedule(static)
+    #pragma omp parallel for schedule(static) num_threads(resolve_num_threads())
     for (int di = 0; di < nnodes; di++){
         Node *dest = nodes[di];
         int k = dest->id;
@@ -1624,7 +1637,7 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         // cross the OpenMP boundary.
         std::exception_ptr gen_exc; int gen_exc_id = INT_MAX;
         std::exception_ptr run_exc; int run_exc_id = INT_MAX;
-        #pragma omp parallel
+        #pragma omp parallel num_threads(resolve_num_threads())
         {
         // Link updates (per-link): Link::update() touches only its own time-indexed arrays
         // and capacities, so it is entity-exclusive and independent of thread count.

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -115,11 +115,11 @@ void Node::generate(){
 
         // Multi-lane acceptance check
         bool can_accept = false;
-        if ((int)outlink->vehicles.size() < outlink->number_of_lanes){
+        if (outlink->q_size() < outlink->number_of_lanes){
             can_accept = true;
         } else {
-            int idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            if (outlink->vehicles[idx]->x() > outlink->delta_per_lane * w->delta_n){
+            int lead = outlink->q_at_seq(outlink->veh_tail_seq - outlink->number_of_lanes);
+            if (w->veh_x[lead] > outlink->delta_per_lane * w->delta_n){
                 can_accept = true;
             }
         }
@@ -151,21 +151,13 @@ void Node::generate(){
         w->vehicles_running[veh->id] = veh;
 
         // Lane assignment
-        if (!outlink->vehicles.empty()){
-            veh->lane() = (outlink->vehicles.back()->lane() + 1) % outlink->number_of_lanes;
+        if (!outlink->q_empty()){
+            veh->lane() = (w->vehicles[outlink->q_back_idx()]->lane() + 1) % outlink->number_of_lanes;
         } else {
             veh->lane() = 0;
         }
 
-        // Leader-Follower (leader is number_of_lanes positions back)
-        veh->leader = nullptr;
-        if ((int)outlink->vehicles.size() >= outlink->number_of_lanes){
-            int leader_idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            veh->leader = outlink->vehicles[leader_idx];
-            veh->leader->follower = veh;
-        }
-
-        outlink->vehicles.push_back(veh);
+        outlink->q_push(veh->idx);
 
         // Cumulative arrival curve
         outlink->arrival_curve[w->timestep] += w->delta_n;
@@ -232,11 +224,11 @@ void Node::transfer(){
     for (auto outlink : outlinks_expanded){
         // Multi-lane acceptance check
         bool can_accept = false;
-        if ((int)outlink->vehicles.size() < outlink->number_of_lanes){
+        if (outlink->q_size() < outlink->number_of_lanes){
             can_accept = true;
         } else {
-            int idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            if (outlink->vehicles[idx]->x() > outlink->delta_per_lane * w->delta_n){
+            int lead = outlink->q_at_seq(outlink->veh_tail_seq - outlink->number_of_lanes);
+            if (w->veh_x[lead] > outlink->delta_per_lane * w->delta_n){
                 can_accept = true;
             }
         }
@@ -257,7 +249,7 @@ void Node::transfer(){
         auto &merge_priorities = _buf_merge_priorities;
         for (auto veh : incoming_vehicles){
             if (veh->route_next_link == outlink &&
-                    veh == veh->link()->vehicles.front() &&
+                    veh == w->vehicles[veh->link()->q_front_idx()] &&
                     veh->link()->capacity_out_remain >= w->delta_n &&
                     (contains(veh->link()->signal_group, signal_phase) || signal_intervals.size() <= 1)){
                 merging_vehs.push_back(veh);
@@ -311,8 +303,9 @@ void Node::transfer(){
 
         chosen_veh->arrival_time_link = (double)w->timestep * w->delta_t;
 
-        // Remove from old link
-        inlink->vehicles.pop_front();
+        // Remove from old link (this also drops the leader link for the vehicle that
+        // was following chosen_veh on inlink: its derived leader is now ahead of head)
+        inlink->q_pop_front();
 
         chosen_veh->set_link(outlink);
         chosen_veh->x() = 0.0;
@@ -325,30 +318,23 @@ void Node::transfer(){
         chosen_veh->_traveled_nodes[outlink->start_node->id] = true;
         chosen_veh->_traveled_link_count++;
 
-        if (chosen_veh->follower){
-            chosen_veh->follower->leader = nullptr;
-        }
-        chosen_veh->follower = nullptr;
-
         // Lane assignment on new link
-        if (!outlink->vehicles.empty()){
-            chosen_veh->lane() = (outlink->vehicles.back()->lane() + 1) % outlink->number_of_lanes;
+        if (!outlink->q_empty()){
+            chosen_veh->lane() = (w->vehicles[outlink->q_back_idx()]->lane() + 1) % outlink->number_of_lanes;
         } else {
             chosen_veh->lane() = 0;
         }
 
-        // Leader-Follower (leader is number_of_lanes positions back in the same lane)
-        chosen_veh->leader = nullptr;
-        if ((int)outlink->vehicles.size() >= outlink->number_of_lanes){
-            int leader_idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            chosen_veh->leader = outlink->vehicles[leader_idx];
-            chosen_veh->leader->follower = chosen_veh;
+        // Leader on new link: number_of_lanes positions back in the pre-push queue
+        Vehicle *chosen_leader = nullptr;
+        if (outlink->q_size() >= outlink->number_of_lanes){
+            chosen_leader = w->vehicles[outlink->q_at_seq(outlink->veh_tail_seq - outlink->number_of_lanes)];
         }
 
         // Move-remain processing: carry residual distance to next link
         double x_next_mr = chosen_veh->move_remain() * outlink->vmax / inlink->vmax;
-        if (chosen_veh->leader != nullptr){
-            double x_cong = chosen_veh->leader->x_old() - outlink->delta_per_lane * w->delta_n;
+        if (chosen_leader != nullptr){
+            double x_cong = chosen_leader->x_old() - outlink->delta_per_lane * w->delta_n;
             if (x_cong < chosen_veh->x()){
                 x_cong = chosen_veh->x();
             }
@@ -367,11 +353,11 @@ void Node::transfer(){
         chosen_veh->move_remain() = 0.0;
 
         // If the new front vehicle of inlink is waiting for trip end, let it end
-        if (!inlink->vehicles.empty() && inlink->vehicles.front()->flag_waiting_for_trip_end){
-            inlink->vehicles.front()->end_trip();
+        if (!inlink->q_empty() && w->vehicles[inlink->q_front_idx()]->flag_waiting_for_trip_end){
+            w->vehicles[inlink->q_front_idx()]->end_trip();
         }
 
-        outlink->vehicles.push_back(chosen_veh);
+        outlink->q_push(chosen_veh->idx);
 
         // Remove from incoming_vehicles
         remove_from_vector(incoming_vehicles, chosen_veh);
@@ -380,8 +366,8 @@ void Node::transfer(){
     // Process trip-end-waiting vehicles at the front of each inlink
     for (auto inlink : in_links){
         for (int lane = 0; lane < inlink->number_of_lanes; lane++){
-            if (!inlink->vehicles.empty() && inlink->vehicles.front()->flag_waiting_for_trip_end){
-                inlink->vehicles.front()->end_trip();
+            if (!inlink->q_empty() && w->vehicles[inlink->q_front_idx()]->flag_waiting_for_trip_end){
+                w->vehicles[inlink->q_front_idx()]->end_trip();
             } else {
                 break;
             }
@@ -461,6 +447,12 @@ Link::Link(
     start_node = w->nodes_map[start_node_name];
     end_node = w->nodes_map[end_node_name];
 
+    // Vehicle queue ring buffer (grows on demand in q_push)
+    veh_ring.assign(8, 0);
+    veh_ring_mask = (int)veh_ring.size() - 1;
+    veh_head_seq = 0;
+    veh_tail_seq = 0;
+
     arrival_curve.resize(w->total_timesteps, 0.0);
     departure_curve.resize(w->total_timesteps, 0.0);
 
@@ -530,12 +522,30 @@ void Link::change_jam_density(double new_value){
 
 int Link::count_vehicles_in_queue() const {
     int count = 0;
-    for (auto veh : vehicles){
-        if (veh->v() < vmax){
+    for (long long s = veh_head_seq; s < veh_tail_seq; s++){
+        if (w->veh_v[veh_ring[s & veh_ring_mask]] < vmax){
             count++;
         }
     }
     return count;
+}
+
+// Append veh_idx to the queue, growing the ring buffer if full (preserving FIFO order
+// and the absolute sequence numbers), and record its entry sequence for leader derivation.
+void Link::q_push(int veh_idx){
+    if (veh_tail_seq - veh_head_seq >= (long long)veh_ring.size()){
+        int newcap = (int)veh_ring.size() * 2;
+        vector<int> newring(newcap, 0);
+        int newmask = newcap - 1;
+        for (long long s = veh_head_seq; s < veh_tail_seq; s++){
+            newring[s & newmask] = veh_ring[s & veh_ring_mask];
+        }
+        veh_ring.swap(newring);
+        veh_ring_mask = newmask;
+    }
+    veh_ring[veh_tail_seq & veh_ring_mask] = veh_idx;
+    w->veh_queue_seq[veh_idx] = veh_tail_seq;
+    veh_tail_seq++;
 }
 
 void Link::set_travel_time(){
@@ -547,12 +557,12 @@ void Link::set_travel_time(){
         return;
     }
     // Instantaneous travel time = length / average speed
-    if (!vehicles.empty()){
+    if (!q_empty()){
         double vsum = 0.0;
-        for (auto veh : vehicles){
-            vsum += veh->v();
+        for (long long s = veh_head_seq; s < veh_tail_seq; s++){
+            vsum += w->veh_v[veh_ring[s & veh_ring_mask]];
         }
-        double avg_v = vsum / (double)vehicles.size();
+        double avg_v = vsum / (double)q_size();
         if (avg_v > 0.0){
             traveltime_instant[w->timestep] = (double)length / avg_v;
         }else{
@@ -674,8 +684,6 @@ Vehicle::Vehicle(
       departure_time(departure_time),
       orig(nullptr),
       dest(nullptr),
-      leader(nullptr),
-      follower(nullptr),
       arrival_time(-1.0),
       travel_time(-1.0),
       arrival_time_link(0.0),
@@ -723,6 +731,7 @@ Vehicle::Vehicle(
     w->veh_state.push_back(vsHOME);
     w->veh_link_id.push_back(-1);
     w->veh_lane.push_back(0);
+    w->veh_queue_seq.push_back(-1);
 
     w->vehicles.push_back(this);
     w->vehicles_living[id] = this;
@@ -760,7 +769,7 @@ void Vehicle::update(){
             if (lk->end_node == dest){
                 // Prepare for trip end (wait if not at front of link)
                 flag_waiting_for_trip_end = 1;
-                if (lk->vehicles.front() == this){
+                if (w->vehicles[lk->q_front_idx()] == this){
                     end_trip();
                 }
             }else if (lk->end_node->out_links.empty() && trip_abort == 1){
@@ -768,7 +777,7 @@ void Vehicle::update(){
                 flag_trip_aborted = 1;
                 route_next_link = nullptr;
                 flag_waiting_for_trip_end = 1;
-                if (lk->vehicles.front() == this){
+                if (w->vehicles[lk->q_front_idx()] == this){
                     end_trip();
                 }
             }else{
@@ -807,11 +816,10 @@ void Vehicle::end_trip(){
     w->vehicles_living.erase(id);
     w->vehicles_running.erase(id);
 
-    lk->vehicles.pop_front();
+    // Pop self from the front of the link (this vehicle is always at the front here);
+    // the trailing vehicle's derived leader becomes null automatically.
+    lk->q_pop_front();
 
-    if (follower){
-        follower->leader = nullptr;
-    }
     set_link(nullptr);
     x() = 0.0;
     flag_waiting_for_trip_end = 0;
@@ -835,8 +843,9 @@ void Vehicle::car_follow_newell(){
     x_next() = x() + lk->vmax * w->delta_t;
 
     // congested (use delta_per_lane for multi-lane car following)
-    if (leader != nullptr){
-        double gap = leader->x() - lk->delta_per_lane * w->delta_n;
+    Vehicle *ld = leader();
+    if (ld != nullptr){
+        double gap = ld->x() - lk->delta_per_lane * w->delta_n;
         if (gap < x()){
             gap = x();
         }
@@ -1012,7 +1021,10 @@ void Vehicle::log_data(){
             log_x.push_back(x());
             log_v.push_back(v());
             log_lane.push_back(lane());
-            log_s.push_back((leader != nullptr && leader->link() == lk) ? leader->x() - x() : -1.0);
+            // The derived leader is always on the same link, so the same-link guard of
+            // the original (leader->link() == lk) is implicit.
+            Vehicle *ld = leader();
+            log_s.push_back(ld != nullptr ? ld->x() - x() : -1.0);
         } else {
             log_link.push_back(-1);
             log_x.push_back(-1);
@@ -1480,9 +1492,9 @@ void World::print_progress_line(double t_print){
     double platoon_count = 0;
     double v_sum = 0;
     for (auto ln : links){
-        platoon_count += (double)ln->vehicles.size();
-        for (auto veh : ln->vehicles){
-            v_sum += veh->v();
+        platoon_count += (double)ln->q_size();
+        for (long long s = ln->veh_head_seq; s < ln->veh_tail_seq; s++){
+            v_sum += veh_v[ln->veh_ring[s & ln->veh_ring_mask]];
         }
     }
     double sum_vehs = platoon_count * delta_n;

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -729,8 +729,9 @@ Vehicle::Vehicle(
     orig = w->nodes_map[orig_name];
     dest = w->nodes_map[dest_name];
 
-    // Initialize link preference (vector indexed by link_id)
-    route_preference.assign(w->links.size(), 0.0);
+    // route_preference is left empty (lazy): the engine never reads Vehicle::route_preference
+    // (route choice uses World::route_preference), so the O(L) per-vehicle zero-fill is skipped.
+    // The Python getter materializes links.size() zeros on demand (see bindings.cpp).
     route_choice_uncertainty = w->route_choice_uncertainty;
 
     // Incremental tracking for no_cyclic_routing and specified_route
@@ -742,15 +743,8 @@ Vehicle::Vehicle(
     log_last_ts = -1;
     log_wait_count = 0;
     log_end_count = 0;
-    if (w->vehicle_log_mode) {
-        // Reserve log arrays: total_timesteps + margin for extra log_data calls
-        size_t log_cap = w->total_timesteps + 10;
-        log_link.reserve(log_cap);
-        log_x.reserve(log_cap);
-        log_v.reserve(log_cap);
-        log_lane.reserve(log_cap);
-        log_s.reserve(log_cap);
-    }
+    // Log arrays are reserved lazily at the first log entry (departure), right-sized to the
+    // remaining horizon instead of the full total_timesteps (see Vehicle::log_data).
 
     idx = (int)w->vehicles.size();
     w->veh_x.push_back(0.0);
@@ -841,32 +835,33 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
     }
 
     // Filter by links_preferred (intersection with linkset)
-    _buf_outlinks.clear();
-    _buf_outlinks.insert(_buf_outlinks.end(), linkset.begin(), linkset.end());
-    auto &outlinks = _buf_outlinks;
+    vector<Link *> &buf_filtered = w->_buf_filtered;
+    w->_buf_outlinks.clear();
+    w->_buf_outlinks.insert(w->_buf_outlinks.end(), linkset.begin(), linkset.end());
+    auto &outlinks = w->_buf_outlinks;
     if (!links_preferred.empty()){
-        _buf_filtered.clear();
+        buf_filtered.clear();
         for (auto ln : outlinks){
             if (contains(links_preferred, ln)){
-                _buf_filtered.push_back(ln);
+                buf_filtered.push_back(ln);
             }
         }
-        if (!_buf_filtered.empty()){
-            outlinks.swap(_buf_filtered);
+        if (!buf_filtered.empty()){
+            outlinks.swap(buf_filtered);
         }
     }
 
     // Filter out links_avoid (subtraction from linkset).
     // As in Python, the subtraction applies whenever any outlink is avoided, even if the result becomes empty; an empty result raises ValueError.
     if (!links_avoid.empty()){
-        _buf_filtered.clear();
+        buf_filtered.clear();
         for (auto ln : outlinks){
             if (!contains(links_avoid, ln)){
-                _buf_filtered.push_back(ln);
+                buf_filtered.push_back(ln);
             }
         }
-        if (_buf_filtered.size() != outlinks.size()){
-            outlinks.swap(_buf_filtered);
+        if (buf_filtered.size() != outlinks.size()){
+            outlinks.swap(buf_filtered);
         }
         if (outlinks.empty()){
             throw std::invalid_argument("Vehicle " + name + ": links_avoid excludes all outgoing links of the current node");
@@ -875,15 +870,15 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
 
     // Filter out links leading to already-traveled nodes (no_cyclic_routing)
     if (w->no_cyclic_routing){
-        _buf_filtered.clear();
+        buf_filtered.clear();
         for (auto ln : outlinks){
             auto end_node_id = ln->end_node->id;
             if (static_cast<size_t>(end_node_id) >= _traveled_nodes.size() || !_traveled_nodes[end_node_id]){
-                _buf_filtered.push_back(ln);
+                buf_filtered.push_back(ln);
             }
         }
-        if (!_buf_filtered.empty()){
-            outlinks.swap(_buf_filtered);
+        if (!buf_filtered.empty()){
+            outlinks.swap(buf_filtered);
         }
     }
 
@@ -894,8 +889,8 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
     }
 
     // Build preference weights (O(1) vector access by link id)
-    _buf_outlink_pref.clear();
-    auto &outlink_pref = _buf_outlink_pref;
+    w->_buf_outlink_pref.clear();
+    auto &outlink_pref = w->_buf_outlink_pref;
     for (auto ln : outlinks){
         outlink_pref.push_back(w->route_preference[dest->id][ln->id]);
     }
@@ -939,6 +934,24 @@ void Vehicle::record_travel_time(Link *link, double t){
 }
 
 /**
+ * @brief Reserve the 5 log arrays right-sized to the remaining horizon.
+ * Called once per vehicle at its first log entry (departure timestep). Upper bound on the
+ * remaining entry count: the log records one entry per timestep from the current timestep
+ * through the last simulated timestep (total_timesteps - 1), i.e. (total_timesteps - timestep)
+ * entries, plus a single END/ABORT tail entry that on the update() path duplicates the final
+ * RUN timestep (+1). A +4 slack absorbs any boundary rounding; the exact bound is +1, so this
+ * never under-reserves and realloc count stays 0.
+ */
+void Vehicle::reserve_log_arrays(){
+    size_t log_cap = w->total_timesteps - w->timestep + 4;
+    log_link.reserve(log_cap);
+    log_x.reserve(log_cap);
+    log_v.reserve(log_cap);
+    log_lane.reserve(log_cap);
+    log_s.reserve(log_cap);
+}
+
+/**
  * @brief Log vehicle data for analysis.
  * Uses reserve'd arrays — push_back is O(1) with no reallocation.
  * log_size tracks actual count (vector::size() is equivalent but log_size avoids any ambiguity if resize was used elsewhere).
@@ -958,7 +971,10 @@ void Vehicle::log_data(){
     }
 
     if (w->vehicle_log_mode){
-        if (log_size == 0) log_first_ts = (int)w->timestep;
+        if (log_size == 0){
+            log_first_ts = (int)w->timestep;
+            reserve_log_arrays();
+        }
         log_last_ts = (int)w->timestep;
         if (state() == vsWAIT) log_wait_count++;
         if (state() == vsEND || state() == vsABORT) log_end_count++;
@@ -998,7 +1014,10 @@ void Vehicle::log_data_run(double spacing){
     w->stat_sample_count += 1.0;
 
     if (w->vehicle_log_mode){
-        if (log_size == 0) log_first_ts = (int)w->timestep;
+        if (log_size == 0){
+            log_first_ts = (int)w->timestep;
+            reserve_log_arrays();
+        }
         log_last_ts = (int)w->timestep;
         log_link.push_back(lk ? lk->id : -1);
         log_x.push_back(x());

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -44,6 +44,9 @@ Node::Node(World *w, const string &node_name, double x, double y, vector<double>
       flow_capacity(flow_capacity),
       number_of_lanes(number_of_lanes){
     w->nodes.push_back(this);
+    // Per-node RNG stream (kind=1) and stat partial sum, seeded/sized by node id.
+    w->node_rngs.push_back(make_entity_rng(w->random_seed, 1u, (unsigned int)id));
+    w->node_stat_count.push_back(0.0);
     w->node_id++;
     w->nodes_map[node_name] = this;
 
@@ -105,8 +108,8 @@ void Node::generate(){
         }
         Vehicle *veh = generation_queue.front();
 
-        // Choose the next link
-        veh->route_next_link_choice(out_links);
+        // Choose the next link (generate uses this node's RNG stream)
+        veh->route_next_link_choice(out_links, w->node_rngs[id]);
 
         if (veh->route_next_link == nullptr){
             break;
@@ -147,8 +150,6 @@ void Node::generate(){
         }
         veh->_traveled_nodes[outlink->start_node->id] = true;
         veh->_traveled_link_count++;
-
-        w->vehicles_running[veh->id] = veh;
 
         // Lane assignment
         if (!outlink->q_empty()){
@@ -197,6 +198,18 @@ void Node::flow_capacity_update(){
  * @brief Transfer vehicles between links at the node.
  */
 void Node::transfer(){
+    // Aggregate the per-link arrival buffers (filled by the RUN pass) into this node's
+    // incoming_vehicles. in_links are iterated in a fixed order; the id-ascending
+    // canonicalization below makes the final order independent of the aggregation order.
+    for (auto inlink : in_links){
+        for (size_t i = 0; i < inlink->arrived_vehicles.size(); i++){
+            incoming_vehicles.push_back(inlink->arrived_vehicles[i]);
+            incoming_vehicles_requests.push_back(inlink->arrived_requests[i]);
+        }
+        inlink->arrived_vehicles.clear();
+        inlink->arrived_requests.clear();
+    }
+
     // Canonicalize incoming order to vehicle idx (== id) ascending. The fused RUN pass
     // registers arriving vehicles in link/queue order rather than id order; restoring id
     // order here keeps the hard_deterministic tie-break and RNG-independent scenarios
@@ -246,7 +259,7 @@ void Node::transfer(){
     if (!w->hard_deterministic_mode){
         for (int i = (int)outlinks_expanded.size() - 1; i > 0; i--){
             std::uniform_int_distribution<int> dist(0, i);
-            int j = dist(w->rng);
+            int j = dist(w->node_rngs[id]);
             std::swap(outlinks_expanded[i], outlinks_expanded[j]);
         }
     }
@@ -304,7 +317,7 @@ void Node::transfer(){
             chosen_veh = random_choice<Vehicle>(
                 merging_vehs,
                 merge_priorities,
-                w->rng);
+                w->node_rngs[id]);
         }
         if (!chosen_veh){
             continue;
@@ -496,6 +509,12 @@ Link::Link(
     end_node->in_links.push_back(this);
 
     w->links.push_back(this);
+    // Per-link RNG stream (kind=2) and stat partial sums, seeded/sized by link id.
+    w->link_rngs.push_back(make_entity_rng(w->random_seed, 2u, (unsigned int)id));
+    w->link_ave_v_sum.push_back(0.0);
+    w->link_ave_vratio_sum.push_back(0.0);
+    w->link_stat_count.push_back(0.0);
+    w->link_trips_completed.push_back(0.0);
     w->link_id++;
     w->links_map[link_name] = this;
 }
@@ -758,7 +777,6 @@ Vehicle::Vehicle(
     w->veh_queue_seq.push_back(-1);
 
     w->vehicles.push_back(this);
-    w->vehicles_living[id] = this;
     w->vehicle_id++;
     w->vehicles_map[vehicle_name] = this;
 }
@@ -768,8 +786,9 @@ Vehicle::Vehicle(
  */
 void Vehicle::end_trip(){
     state() = vsEND;
-    w->trips_completed_count += 1.0;
     Link *lk = link();
+    // Per-link completed-trip counter (end_trip runs in this link's exclusive context).
+    w->link_trips_completed[lk->id] += 1.0;
     lk->departure_curve[w->timestep] += w->delta_n;
 
     // Record traveltime_real event (lazily materialized on read, matching Python's traveltime_actual slice update)
@@ -784,9 +803,6 @@ void Vehicle::end_trip(){
 
     arrival_time = (double)w->timestep * w->delta_t;
     travel_time = arrival_time - departure_time;
-
-    w->vehicles_living.erase(id);
-    w->vehicles_running.erase(id);
 
     // Pop self from the front of the link (this vehicle is always at the front here);
     // the trailing vehicle's derived leader becomes null automatically.
@@ -811,7 +827,7 @@ void Vehicle::end_trip(){
  * 
  * @param linkset Available links to choose from.
  */
-void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
+void Vehicle::route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng){
     if (linkset.empty()){
         route_next_link = nullptr;
         route_choice_flag_on_link = 1;
@@ -908,7 +924,7 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
         route_next_link = random_choice<Link>(
             outlinks,
             outlink_pref,
-            w->rng);
+            rng);
     }
     route_choice_flag_on_link = 1;
 }
@@ -961,13 +977,15 @@ void Vehicle::log_data(){
     // A waiting vehicle counts as a zero-speed sample for the average speed statistic, as in Python's record_log.
     Link *lk = link();
     if (state() == vsRUN){
-        w->ave_v_sum += v();
+        // RUN samples accumulate on the current link's partial sums.
         if (lk){
-            w->ave_vratio_sum += v() / lk->vmax;
+            w->link_ave_v_sum[lk->id] += v();
+            w->link_ave_vratio_sum[lk->id] += v() / lk->vmax;
+            w->link_stat_count[lk->id] += 1.0;
         }
-        w->stat_sample_count += 1.0;
     } else if (state() == vsWAIT){
-        w->stat_sample_count += 1.0;
+        // WAIT samples accumulate on the origin node (where the vehicle queues).
+        w->node_stat_count[orig->id] += 1.0;
     }
 
     if (w->vehicle_log_mode){
@@ -1006,13 +1024,10 @@ void Vehicle::log_data(){
  * reproduce the id-ordered read semantics of the original update() loop).
  */
 void Vehicle::log_data_run(double spacing){
+    // RUN stat samples (ave_v_sum/ave_vratio_sum/stat_count) are accumulated by the fused
+    // RUN pass into per-link locals flushed once per link, to keep this hot path free of
+    // per-vehicle vector-indexed accumulation. This method only writes the log arrays.
     Link *lk = link();
-    w->ave_v_sum += v();
-    if (lk){
-        w->ave_vratio_sum += v() / lk->vmax;
-    }
-    w->stat_sample_count += 1.0;
-
     if (w->vehicle_log_mode){
         if (log_size == 0){
             log_first_ts = (int)w->timestep;
@@ -1122,11 +1137,6 @@ World::World(
       ave_vratio(0.0),
       trips_total(0.0),
       trips_completed(0.0),
-      ave_v_sum(0.0),
-      ave_vratio_sum(0.0),
-      stat_sample_count(0.0),
-      trips_completed_count(0.0),
-      rng((std::mt19937::result_type)random_seed),
       flag_initialized(false),
       writer(&std::cout){
     // The route update interval has a minimum of 1 timestep, like Python's DELTAT_ROUTE.
@@ -1148,8 +1158,6 @@ World::~World(){
     vehicles.clear();
     links.clear();
     nodes.clear();
-    vehicles_living.clear();
-    vehicles_running.clear();
     nodes_map.clear();
     links_map.clear();
     vehicles_map.clear();
@@ -1210,7 +1218,7 @@ void World::update_adj_time_matrix(){
         if (hard_deterministic_mode){
             new_link_tt = tt + penalty;
         } else {
-            double noise_factor = random_range_float64(1.0, 1.0 + noise, rng);
+            double noise_factor = random_range_float64(1.0, 1.0 + noise, link_rngs[ln->id]);
             new_link_tt = tt * noise_factor + penalty;
         }
         // If there are multiple links between the same nodes, average the travel time
@@ -1459,13 +1467,38 @@ void World::print_scenario_stats(){
     }
 }
 
+// Id-ordered reductions of the per-entity statistic partial sums. Summation is over
+// index (== entity id) in ascending order so repeated reads are bit-identical.
+double World::ave_v_sum() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_ave_v_sum.size(); i++) s += link_ave_v_sum[i];
+    return s;
+}
+double World::ave_vratio_sum() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_ave_vratio_sum.size(); i++) s += link_ave_vratio_sum[i];
+    return s;
+}
+double World::stat_sample_count() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_stat_count.size(); i++) s += link_stat_count[i];
+    for (size_t i = 0; i < node_stat_count.size(); i++) s += node_stat_count[i];
+    return s;
+}
+double World::trips_completed_count() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_trips_completed.size(); i++) s += link_trips_completed[i];
+    return s;
+}
+
 void World::print_simple_results(){
     // Compute from incrementally accumulated stats (no log scan needed)
     trips_total = (double)vehicles.size() * delta_n;
-    trips_completed = trips_completed_count * delta_n;
-    if (stat_sample_count > 0){
-        ave_v = ave_v_sum / stat_sample_count;
-        ave_vratio = ave_vratio_sum / stat_sample_count;
+    trips_completed = trips_completed_count() * delta_n;
+    double n_samples = stat_sample_count();
+    if (n_samples > 0){
+        ave_v = ave_v_sum() / n_samples;
+        ave_vratio = ave_vratio_sum() / n_samples;
     }
 
     (*writer) << "Stats:\n";
@@ -1579,8 +1612,11 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             int lanes = lk->number_of_lanes;
             int mask = lk->veh_ring_mask;
             double dpl_dn = lk->delta_per_lane * delta_n;
-            double vmax_dt = lk->vmax * delta_t;
+            double vmax = lk->vmax;
+            double vmax_dt = vmax * delta_t;
             double length = lk->length;
+            // Per-link stat partial sums accumulated as locals, flushed once after the sweep.
+            double l_ave_v = 0.0, l_ave_vratio = 0.0, l_stat = 0.0;
             for (long long s = head0; s < tail0; s++){
                 int vi = lk->veh_ring[s & mask];
                 Vehicle *veh = vehicles[vi];
@@ -1625,6 +1661,13 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
                 }
                 veh->log_data_run(spacing);
 
+                // RUN stat sample: v() here is the pre-move veh_v (set at link entry / last
+                // step), matching the original log_data_run accumulation point.
+                double vv = veh_v[vi];
+                l_ave_v += vv;
+                l_ave_vratio += vv / vmax;
+                l_stat += 1.0;
+
                 // move + link-end handling (identical to the old update() RUN branch)
                 if (self_x == 0.0){
                     veh->route_choice_flag_on_link = 0;
@@ -1648,12 +1691,18 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
                             veh->end_trip();
                         }
                     } else {
-                        veh->route_next_link_choice(lk->end_node->out_links);
-                        lk->end_node->incoming_vehicles.push_back(veh);
-                        lk->end_node->incoming_vehicles_requests.push_back(veh->route_next_link);
+                        // RUN-path route choice uses the current link's RNG stream. The
+                        // arrival is buffered on this link and aggregated into the end node's
+                        // incoming_vehicles at the start of Node::transfer.
+                        veh->route_next_link_choice(lk->end_node->out_links, link_rngs[lk->id]);
+                        lk->arrived_vehicles.push_back(veh);
+                        lk->arrived_requests.push_back(veh->route_next_link);
                     }
                 }
             }
+            link_ave_v_sum[lk->id] += l_ave_v;
+            link_ave_vratio_sum[lk->id] += l_ave_vratio;
+            link_stat_count[lk->id] += l_stat;
         }
 
         // WAIT system pass: vehicles still in a generation_queue (those not generated this

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -119,7 +119,7 @@ void Node::generate(){
             can_accept = true;
         } else {
             int idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            if (outlink->vehicles[idx]->x > outlink->delta_per_lane * w->delta_n){
+            if (outlink->vehicles[idx]->x() > outlink->delta_per_lane * w->delta_n){
                 can_accept = true;
             }
         }
@@ -134,10 +134,10 @@ void Node::generate(){
         // Accept vehicle
         generation_queue.pop_front();
 
-        veh->state = vsRUN;
-        veh->link = outlink;
-        veh->x = 0.0;
-        veh->v = outlink->vmax;  // initial speed at link entry (matches Python)
+        veh->state() = vsRUN;
+        veh->set_link(outlink);
+        veh->x() = 0.0;
+        veh->v() = outlink->vmax;  // initial speed at link entry (matches Python)
         veh->record_travel_time(nullptr, (double)w->timestep * w->delta_t);
 
         // Track visited nodes for no_cyclic_routing and link count for specified_route
@@ -152,9 +152,9 @@ void Node::generate(){
 
         // Lane assignment
         if (!outlink->vehicles.empty()){
-            veh->lane = (outlink->vehicles.back()->lane + 1) % outlink->number_of_lanes;
+            veh->lane() = (outlink->vehicles.back()->lane() + 1) % outlink->number_of_lanes;
         } else {
-            veh->lane = 0;
+            veh->lane() = 0;
         }
 
         // Leader-Follower (leader is number_of_lanes positions back)
@@ -236,7 +236,7 @@ void Node::transfer(){
             can_accept = true;
         } else {
             int idx = (int)outlink->vehicles.size() - outlink->number_of_lanes;
-            if (outlink->vehicles[idx]->x > outlink->delta_per_lane * w->delta_n){
+            if (outlink->vehicles[idx]->x() > outlink->delta_per_lane * w->delta_n){
                 can_accept = true;
             }
         }
@@ -257,11 +257,11 @@ void Node::transfer(){
         auto &merge_priorities = _buf_merge_priorities;
         for (auto veh : incoming_vehicles){
             if (veh->route_next_link == outlink &&
-                    veh == veh->link->vehicles.front() &&
-                    veh->link->capacity_out_remain >= w->delta_n &&
-                    (contains(veh->link->signal_group, signal_phase) || signal_intervals.size() <= 1)){
+                    veh == veh->link()->vehicles.front() &&
+                    veh->link()->capacity_out_remain >= w->delta_n &&
+                    (contains(veh->link()->signal_group, signal_phase) || signal_intervals.size() <= 1)){
                 merging_vehs.push_back(veh);
-                merge_priorities.push_back(veh->link ? veh->link->merge_priority : 1.0);
+                merge_priorities.push_back(veh->link() ? veh->link()->merge_priority : 1.0);
             }
         }
         if (merging_vehs.empty()){
@@ -288,7 +288,7 @@ void Node::transfer(){
             continue;
         }
 
-        Link *inlink = chosen_veh->link;
+        Link *inlink = chosen_veh->link();
 
         // Update capacity
         inlink->capacity_out_remain -= w->delta_n;
@@ -314,8 +314,8 @@ void Node::transfer(){
         // Remove from old link
         inlink->vehicles.pop_front();
 
-        chosen_veh->link = outlink;
-        chosen_veh->x = 0.0;
+        chosen_veh->set_link(outlink);
+        chosen_veh->x() = 0.0;
 
         // Track visited nodes for no_cyclic_routing and link count for specified_route
         const std::size_t required_size = w->nodes.size();
@@ -332,9 +332,9 @@ void Node::transfer(){
 
         // Lane assignment on new link
         if (!outlink->vehicles.empty()){
-            chosen_veh->lane = (outlink->vehicles.back()->lane + 1) % outlink->number_of_lanes;
+            chosen_veh->lane() = (outlink->vehicles.back()->lane() + 1) % outlink->number_of_lanes;
         } else {
-            chosen_veh->lane = 0;
+            chosen_veh->lane() = 0;
         }
 
         // Leader-Follower (leader is number_of_lanes positions back in the same lane)
@@ -346,11 +346,11 @@ void Node::transfer(){
         }
 
         // Move-remain processing: carry residual distance to next link
-        double x_next_mr = chosen_veh->move_remain * outlink->vmax / inlink->vmax;
+        double x_next_mr = chosen_veh->move_remain() * outlink->vmax / inlink->vmax;
         if (chosen_veh->leader != nullptr){
-            double x_cong = chosen_veh->leader->x_old - outlink->delta_per_lane * w->delta_n;
-            if (x_cong < chosen_veh->x){
-                x_cong = chosen_veh->x;
+            double x_cong = chosen_veh->leader->x_old() - outlink->delta_per_lane * w->delta_n;
+            if (x_cong < chosen_veh->x()){
+                x_cong = chosen_veh->x();
             }
             if (x_next_mr > x_cong){
                 x_next_mr = x_cong;
@@ -362,9 +362,9 @@ void Node::transfer(){
         if (x_next_mr < 0.0){
             x_next_mr = 0.0;
         }
-        chosen_veh->x = x_next_mr;
-        chosen_veh->v += chosen_veh->x / w->delta_t;
-        chosen_veh->move_remain = 0.0;
+        chosen_veh->x() = x_next_mr;
+        chosen_veh->v() += chosen_veh->x() / w->delta_t;
+        chosen_veh->move_remain() = 0.0;
 
         // If the new front vehicle of inlink is waiting for trip end, let it end
         if (!inlink->vehicles.empty() && inlink->vehicles.front()->flag_waiting_for_trip_end){
@@ -531,7 +531,7 @@ void Link::change_jam_density(double new_value){
 int Link::count_vehicles_in_queue() const {
     int count = 0;
     for (auto veh : vehicles){
-        if (veh->v < vmax){
+        if (veh->v() < vmax){
             count++;
         }
     }
@@ -550,7 +550,7 @@ void Link::set_travel_time(){
     if (!vehicles.empty()){
         double vsum = 0.0;
         for (auto veh : vehicles){
-            vsum += veh->v;
+            vsum += veh->v();
         }
         double avg_v = vsum / (double)vehicles.size();
         if (avg_v > 0.0){
@@ -674,16 +674,8 @@ Vehicle::Vehicle(
       departure_time(departure_time),
       orig(nullptr),
       dest(nullptr),
-      link(nullptr),
-      x(0.0),
-      x_next(0.0),
-      x_old(0.0),
-      v(0.0),
-      move_remain(0.0),
-      lane(0),
       leader(nullptr),
       follower(nullptr),
-      state(vsHOME),
       arrival_time(-1.0),
       travel_time(-1.0),
       arrival_time_link(0.0),
@@ -722,6 +714,16 @@ Vehicle::Vehicle(
         log_s.reserve(log_cap);
     }
 
+    idx = (int)w->vehicles.size();
+    w->veh_x.push_back(0.0);
+    w->veh_x_next.push_back(0.0);
+    w->veh_x_old.push_back(0.0);
+    w->veh_v.push_back(0.0);
+    w->veh_move_remain.push_back(0.0);
+    w->veh_state.push_back(vsHOME);
+    w->veh_link_id.push_back(-1);
+    w->veh_lane.push_back(0);
+
     w->vehicles.push_back(this);
     w->vehicles_living[id] = this;
     w->vehicle_id++;
@@ -733,48 +735,49 @@ Vehicle::Vehicle(
  */
 void Vehicle::update(){
 
-    if (state == vsHOME){
+    if (state() == vsHOME){
         if ((double)w->timestep * w->delta_t >= departure_time){
             log_data();
-            state = vsWAIT;
+            state() = vsWAIT;
             orig->generation_queue.push_back(this);
         }
-    }else if (state == vsWAIT){
+    }else if (state() == vsWAIT){
         log_data();
-    }else if (state == vsRUN){
+    }else if (state() == vsRUN){
         log_data();
-        if (x == 0.0){
+        if (x() == 0.0){
             route_choice_flag_on_link = 0;
         }
 
-        v = (x_next - x) / (w->delta_t);
-        x_old = x;
-        x = x_next;
+        v() = (x_next() - x()) / (w->delta_t);
+        x_old() = x();
+        x() = x_next();
 
-        distance_traveled += x - x_old;
+        distance_traveled += x() - x_old();
 
-        if (std::fabs(x - link->length) < 1e-9){
-            if (link->end_node == dest){
+        Link *lk = link();
+        if (std::fabs(x() - lk->length) < 1e-9){
+            if (lk->end_node == dest){
                 // Prepare for trip end (wait if not at front of link)
                 flag_waiting_for_trip_end = 1;
-                if (link->vehicles.front() == this){
+                if (lk->vehicles.front() == this){
                     end_trip();
                 }
-            }else if (link->end_node->out_links.empty() && trip_abort == 1){
+            }else if (lk->end_node->out_links.empty() && trip_abort == 1){
                 // Dead-end: abort trip
                 flag_trip_aborted = 1;
                 route_next_link = nullptr;
                 flag_waiting_for_trip_end = 1;
-                if (link->vehicles.front() == this){
+                if (lk->vehicles.front() == this){
                     end_trip();
                 }
             }else{
-                route_next_link_choice(link->end_node->out_links);
-                link->end_node->incoming_vehicles.push_back(this);
-                link->end_node->incoming_vehicles_requests.push_back(route_next_link);
+                route_next_link_choice(lk->end_node->out_links);
+                lk->end_node->incoming_vehicles.push_back(this);
+                lk->end_node->incoming_vehicles_requests.push_back(route_next_link);
             }
         }
-    }else if (state == vsEND || state == vsABORT){
+    }else if (state() == vsEND || state() == vsABORT){
         // do nothing
     }
 }
@@ -783,19 +786,20 @@ void Vehicle::update(){
  * @brief End the vehicle's trip.
  */
 void Vehicle::end_trip(){
-    state = vsEND;
+    state() = vsEND;
     w->trips_completed_count += 1.0;
-    link->departure_curve[w->timestep] += w->delta_n;
+    Link *lk = link();
+    lk->departure_curve[w->timestep] += w->delta_n;
 
     // Record traveltime_real event (lazily materialized on read, matching Python's traveltime_actual slice update)
     {
         double current_tt = ((double)w->timestep + 1.0) * w->delta_t - arrival_time_link;
         int start_idx = (int)(arrival_time_link / w->delta_t);
         if (start_idx < 0) start_idx = 0;
-        link->traveltime_real_events.emplace_back(start_idx, current_tt);
+        lk->traveltime_real_events.emplace_back(start_idx, current_tt);
     }
 
-    record_travel_time(link, (double)w->timestep * w->delta_t);
+    record_travel_time(lk, (double)w->timestep * w->delta_t);
 
     arrival_time = (double)w->timestep * w->delta_t;
     travel_time = arrival_time - departure_time;
@@ -803,17 +807,17 @@ void Vehicle::end_trip(){
     w->vehicles_living.erase(id);
     w->vehicles_running.erase(id);
 
-    link->vehicles.pop_front();
+    lk->vehicles.pop_front();
 
     if (follower){
         follower->leader = nullptr;
     }
-    link = nullptr;
-    x = 0.0;
+    set_link(nullptr);
+    x() = 0.0;
     flag_waiting_for_trip_end = 0;
 
     if (flag_trip_aborted){
-        state = vsABORT;
+        state() = vsABORT;
         arrival_time = -1.0;
         travel_time = -1.0;
     }
@@ -826,29 +830,30 @@ void Vehicle::end_trip(){
  * @brief Apply Newell's car-following model.
  */
 void Vehicle::car_follow_newell(){
+    Link *lk = link();
     // free-flow
-    x_next = x + link->vmax * w->delta_t;
+    x_next() = x() + lk->vmax * w->delta_t;
 
     // congested (use delta_per_lane for multi-lane car following)
     if (leader != nullptr){
-        double gap = leader->x - link->delta_per_lane * w->delta_n;
-        if (gap < x){
-            gap = x;
+        double gap = leader->x() - lk->delta_per_lane * w->delta_n;
+        if (gap < x()){
+            gap = x();
         }
-        if (x_next > gap){
-            x_next = gap;
+        if (x_next() > gap){
+            x_next() = gap;
         }
     }
 
     // non-decreasing
-    if (x_next < x){
-        x_next = x;
+    if (x_next() < x()){
+        x_next() = x();
     }
 
     // clamp to link length, carry over residual as move_remain
-    if (x_next > link->length){
-        move_remain = x_next - link->length;
-        x_next = link->length;
+    if (x_next() > lk->length){
+        move_remain() = x_next() - lk->length;
+        x_next() = lk->length;
     }
 }
 
@@ -986,27 +991,28 @@ void Vehicle::record_travel_time(Link *link, double t){
 void Vehicle::log_data(){
     // Accumulate stats for print_simple_results (regardless of log mode).
     // A waiting vehicle counts as a zero-speed sample for the average speed statistic, as in Python's record_log.
-    if (state == vsRUN){
-        w->ave_v_sum += v;
-        if (link){
-            w->ave_vratio_sum += v / link->vmax;
+    Link *lk = link();
+    if (state() == vsRUN){
+        w->ave_v_sum += v();
+        if (lk){
+            w->ave_vratio_sum += v() / lk->vmax;
         }
         w->stat_sample_count += 1.0;
-    } else if (state == vsWAIT){
+    } else if (state() == vsWAIT){
         w->stat_sample_count += 1.0;
     }
 
     if (w->vehicle_log_mode){
         if (log_size == 0) log_first_ts = (int)w->timestep;
         log_last_ts = (int)w->timestep;
-        if (state == vsWAIT) log_wait_count++;
-        if (state == vsEND || state == vsABORT) log_end_count++;
-        if (state == vsRUN){
-            log_link.push_back(link ? link->id : -1);
-            log_x.push_back(x);
-            log_v.push_back(v);
-            log_lane.push_back(lane);
-            log_s.push_back((leader != nullptr && leader->link == link) ? leader->x - x : -1.0);
+        if (state() == vsWAIT) log_wait_count++;
+        if (state() == vsEND || state() == vsABORT) log_end_count++;
+        if (state() == vsRUN){
+            log_link.push_back(lk ? lk->id : -1);
+            log_x.push_back(x());
+            log_v.push_back(v());
+            log_lane.push_back(lane());
+            log_s.push_back((leader != nullptr && leader->link() == lk) ? leader->x() - x() : -1.0);
         } else {
             log_link.push_back(-1);
             log_x.push_back(-1);
@@ -1035,7 +1041,7 @@ double Vehicle::log_t_at(size_t i) const {
  * Log structure is always: HOME x1, WAIT x log_wait_count, RUN x r, [END|ABORT] x log_end_count.
  */
 int Vehicle::log_state_at(size_t i) const {
-    if (log_end_count > 0 && i >= log_size - (size_t)log_end_count) return state;
+    if (log_end_count > 0 && i >= log_size - (size_t)log_end_count) return state();
     if (i == 0) return vsHOME;
     if (i < (size_t)(1 + log_wait_count)) return vsWAIT;
     return vsRUN;
@@ -1476,7 +1482,7 @@ void World::print_progress_line(double t_print){
     for (auto ln : links){
         platoon_count += (double)ln->vehicles.size();
         for (auto veh : ln->vehicles){
-            v_sum += veh->v;
+            v_sum += veh->v();
         }
     }
     double sum_vehs = platoon_count * delta_n;
@@ -1521,7 +1527,7 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
     // HOME/WAIT/RUN vehicles in id order; compacted in place each step to drop vehicles that reach END/ABORT (much faster when many have finished).
     update_order.clear();
     for (auto veh : vehicles){
-        if (veh->state <= vsRUN) update_order.push_back(veh);
+        if (veh->state() <= vsRUN) update_order.push_back(veh);
     }
 
     for (timestep = start_ts; timestep < end_ts; timestep++){
@@ -1552,7 +1558,7 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
 
         // car-following (update_order is in id order, so hard_deterministic semantics hold)
         for (auto veh : update_order){
-            if (veh->state == vsRUN){
+            if (veh->state() == vsRUN){
                 veh->car_follow_newell();
             }
         }
@@ -1561,10 +1567,10 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         size_t wpos = 0;
         for (size_t r = 0; r < update_order.size(); r++){
             Vehicle *veh = update_order[r];
-            if (veh->state <= vsRUN){
+            if (veh->state() <= vsRUN){
                 veh->update();
             }
-            if (veh->state <= vsRUN){
+            if (veh->state() <= vsRUN){
                 update_order[wpos++] = veh;
             }
         }
@@ -1689,7 +1695,7 @@ std::vector<std::pair<std::string, int>> World::get_all_vehicle_states() const {
     std::vector<std::pair<std::string, int>> result;
     result.reserve(vehicles.size());
     for (auto *v : vehicles) {
-        int effective_state = v->state;
+        int effective_state = v->state();
         if (effective_state == vsEND && (v->flag_trip_aborted || (v->arrival_time < 0 && v->travel_time <= 0))) {
             effective_state = vsABORT;
         }
@@ -1758,7 +1764,7 @@ World::CompactFlatLogs World::build_all_vehicle_logs_flat_compact() const {
                 prev_lid = lid;
             }
         }
-        if (v->state == vsEND) ltl_count++;
+        if (v->state() == vsEND) ltl_count++;
         fl.ltl_offsets[vi] = total_ltl;
         total_ltl += ltl_count;
     }
@@ -1811,7 +1817,7 @@ World::CompactFlatLogs World::build_all_vehicle_logs_flat_compact() const {
                 prev_lid = lid;
             }
         }
-        if (v->state == vsEND) {
+        if (v->state() == vsEND) {
             fl.ltl_t[ltl_base + ltl_idx] = (v->arrival_time >= 0) ? v->arrival_time : -1.0;
             fl.ltl_id[ltl_base + ltl_idx] = Vehicle::LOG_T_LINK_END;
             ltl_idx++;

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -12,12 +12,21 @@
 #include <algorithm>
 #include <chrono>
 #include <queue>
+#include <climits>
+#include <exception>
 
 #include "traffi.h"
 
 using std::string, std::vector, std::deque, std::pair, std::map, std::unordered_map;
 using std::round, std::floor, std::ceil;
 using std::cout, std::endl;
+
+// Thread-local scratch for Vehicle::route_next_link_choice(). The generate pass (per-node)
+// and the RUN pass (per-link) call route choice concurrently, so these buffers must be
+// per-thread; a single World-shared buffer would race. They are cleared on each call.
+static thread_local vector<Link *> tls_buf_outlinks;
+static thread_local vector<Link *> tls_buf_filtered;
+static thread_local vector<double> tls_buf_outlink_pref;
 
 // -----------------------------------------------------------------------
 // MARK: Node 
@@ -851,10 +860,10 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset, std::mt19937 
     }
 
     // Filter by links_preferred (intersection with linkset)
-    vector<Link *> &buf_filtered = w->_buf_filtered;
-    w->_buf_outlinks.clear();
-    w->_buf_outlinks.insert(w->_buf_outlinks.end(), linkset.begin(), linkset.end());
-    auto &outlinks = w->_buf_outlinks;
+    vector<Link *> &buf_filtered = tls_buf_filtered;
+    tls_buf_outlinks.clear();
+    tls_buf_outlinks.insert(tls_buf_outlinks.end(), linkset.begin(), linkset.end());
+    auto &outlinks = tls_buf_outlinks;
     if (!links_preferred.empty()){
         buf_filtered.clear();
         for (auto ln : outlinks){
@@ -905,8 +914,8 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset, std::mt19937 
     }
 
     // Build preference weights (O(1) vector access by link id)
-    w->_buf_outlink_pref.clear();
-    auto &outlink_pref = w->_buf_outlink_pref;
+    tls_buf_outlink_pref.clear();
+    auto &outlink_pref = tls_buf_outlink_pref;
     for (auto ln : outlinks){
         outlink_pref.push_back(w->route_preference[dest->id][ln->id]);
     }
@@ -1259,36 +1268,43 @@ void World::route_search_all(const vector<vector<double>> &adj, double infty) {
         rsa_dist[i].assign(nsize, infty);
         rsa_next[i].assign(nsize, -1);
     }
-    rsa_visited.resize(nsize);
 
     using pdi = pair<double, int>;
-    std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
 
-    // Dijkstra from each source node
-    for (int start = 0; start < nsize; start++) {
-        std::fill(rsa_visited.begin(), rsa_visited.end(), (char)0);
-        auto &dstart = rsa_dist[start];
-        auto &nhstart = rsa_next[start];
-        dstart[start] = 0.0;
-        nhstart[start] = start;
-        pq.push({0.0, start});
+    // Dijkstra from each source node. Each source writes only its own rsa_dist[start] /
+    // rsa_next[start] rows, and rsa_adj_list is read-only here, so the source loop is
+    // parallel-safe with per-thread visited flags and priority queue (the shared scratch is
+    // thread-local). The result is independent of thread count.
+    #pragma omp parallel
+    {
+        vector<char> visited(nsize);
+        std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
+        #pragma omp for schedule(static)
+        for (int start = 0; start < nsize; start++) {
+            std::fill(visited.begin(), visited.end(), (char)0);
+            auto &dstart = rsa_dist[start];
+            auto &nhstart = rsa_next[start];
+            dstart[start] = 0.0;
+            nhstart[start] = start;
+            pq.push({0.0, start});
 
-        while (!pq.empty()) {
-            auto [d, current] = pq.top();
-            pq.pop();
+            while (!pq.empty()) {
+                auto [d, current] = pq.top();
+                pq.pop();
 
-            if (rsa_visited[current]) continue;
-            rsa_visited[current] = 1;
+                if (visited[current]) continue;
+                visited[current] = 1;
 
-            // Explore neighbors via adjacency list
-            double dcur = dstart[current];
-            for (const auto& [next, weight] : rsa_adj_list[current]) {
-                double new_dist = dcur + weight;
-                if (new_dist < dstart[next]) {
-                    dstart[next] = new_dist;
-                    // Update next hop
-                    nhstart[next] = (current == start) ? next : nhstart[current];
-                    pq.push({new_dist, next});
+                // Explore neighbors via adjacency list
+                double dcur = dstart[current];
+                for (const auto& [next, weight] : rsa_adj_list[current]) {
+                    double new_dist = dcur + weight;
+                    if (new_dist < dstart[next]) {
+                        dstart[next] = new_dist;
+                        // Update next hop
+                        nhstart[next] = (current == start) ? next : nhstart[current];
+                        pq.push({new_dist, next});
+                    }
                 }
             }
         }
@@ -1395,7 +1411,13 @@ World::enumerate_k_random_routes_cpp(int k, unsigned int seed){
  * @brief Update route choice using dynamic user optimum.
  */
 void World::route_choice_duo(){
-    for (auto dest : nodes){
+    // Per-destination: route_preference[k] and route_pref_active[k] are exclusive to dest k;
+    // route_next and links are read-only here, so the destination loop is parallel-safe and
+    // independent of thread count.
+    int nnodes = (int)nodes.size();
+    #pragma omp parallel for schedule(static)
+    for (int di = 0; di < nnodes; di++){
+        Node *dest = nodes[di];
         int k = dest->id;
 
         // psum==0.0 iff route_preference[k] has never been reinforced.
@@ -1427,7 +1449,11 @@ void World::route_choice_duo_gradual(){
     // Gradual DUO update: scaled weight applied every timestep
     double weight0 = duo_update_weight * (delta_t / duo_update_time);
 
-    for (auto dest : nodes){
+    // Per-destination and thread-count independent (see route_choice_duo).
+    int nnodes = (int)nodes.size();
+    #pragma omp parallel for schedule(static)
+    for (int di = 0; di < nnodes; di++){
+        Node *dest = nodes[di];
         int k = dest->id;
 
         // psum==0.0 iff route_preference[k] has never been reinforced (see route_choice_duo).
@@ -1585,28 +1611,67 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             print_progress_line(time);
         }
 
-        // Link updates
-        for (auto ln : links){
-            ln->update();
+        int nlinks = (int)links.size();
+        int nnodes = (int)nodes.size();
+
+        // All entity-exclusive timestep stages run inside a single parallel region to keep the
+        // OpenMP setup/barrier overhead low (one region per timestep instead of one per stage;
+        // this keeps the 1-thread path lean). Each `omp for` has an implicit barrier, so the
+        // stage order (update -> generate -> transfer -> RUN -> WAIT) and its data dependencies
+        // are preserved. The serial transfer runs in an `omp single`. Exceptions thrown by
+        // route_next_link_choice (specified_route) are captured per stage (smallest entity id
+        // wins, for determinism) and rethrown after the region, since an exception must never
+        // cross the OpenMP boundary.
+        std::exception_ptr gen_exc; int gen_exc_id = INT_MAX;
+        std::exception_ptr run_exc; int run_exc_id = INT_MAX;
+        #pragma omp parallel
+        {
+        // Link updates (per-link): Link::update() touches only its own time-indexed arrays
+        // and capacities, so it is entity-exclusive and independent of thread count.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nlinks; i++){
+            links[i]->update();
         }
 
-        // Node generate + update (matches Python: node.generate() then node.update())
-        for (auto nd : nodes){
-            nd->generate();
+        // Node generate + signal + capacity (per-node): a node's out_links are its exclusive
+        // property (a link has a single start_node), and generate() uses this node's RNG
+        // stream; signal/capacity touch only this node.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nnodes; i++){
+            Node *nd = nodes[i];
+            try {
+                nd->generate();
+            } catch (...) {
+                #pragma omp critical (ecs_exc)
+                { if (nd->id < gen_exc_id){ gen_exc_id = nd->id; gen_exc = std::current_exception(); } }
+            }
             nd->signal_update();
             nd->flow_capacity_update();
         }
 
-        // Node transfer
-        for (auto nd : nodes){
-            nd->transfer();
+        // Node transfer: serial. Serial id-ordered node processing has a sequential visibility
+        // semantics (a node's acceptance decisions are seen by later nodes through the shared
+        // out-link queues), matching Python; parallelizing it would break bit identity.
+        #pragma omp single
+        {
+            for (auto nd : nodes){
+                nd->transfer();
+            }
         }
 
         // RUN system pass: fuse the old car_follow + update(RUN) into a single link-ordered
         // sweep. Each link is processed front-to-back over a head/tail snapshot so leaders
         // (ahead in the queue) are moved before their followers, matching the old two-phase
         // (car_follow-all then update-all) reads via x_old.
-        for (auto lk : links){
+        // Parallel per-link: a vehicle is on exactly one link, so each link touches only its
+        // own ring/queue, its own vehicles' SoA state and logs, its own curves/traveltime
+        // events/arrived buffers, its own stat partial sums and RNG stream. The result is
+        // independent of thread count. route_next_link_choice may throw (specified_route);
+        // capture and rethrow the smallest-link-id exception after the region.
+        #pragma omp for schedule(static)
+        for (int li = 0; li < nlinks; li++){
+          Link *lk = links[li];
+          try {
             long long head0 = lk->veh_head_seq;
             long long tail0 = lk->veh_tail_seq;
             int lanes = lk->number_of_lanes;
@@ -1703,16 +1768,27 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             link_ave_v_sum[lk->id] += l_ave_v;
             link_ave_vratio_sum[lk->id] += l_ave_vratio;
             link_stat_count[lk->id] += l_stat;
+          } catch (...) {
+            #pragma omp critical (ecs_exc)
+            { if (lk->id < run_exc_id){ run_exc_id = lk->id; run_exc = std::current_exception(); } }
+          }
         }
 
-        // WAIT system pass: vehicles still in a generation_queue (those not generated this
-        // step) log a WAIT entry. Vehicles departing this step are logged as HOME below and
-        // enter the queue only afterwards, so they are not double-logged here.
-        for (auto nd : nodes){
-            for (auto veh : nd->generation_queue){
+        // WAIT system pass (per-node): vehicles still in a generation_queue (those not
+        // generated this step) log a WAIT entry. A queued vehicle's origin is this node, so
+        // its WAIT stat sample (node_stat_count[orig->id]) and per-vehicle log are exclusive
+        // to this node; the pass is thread-count independent. Vehicles departing this step are
+        // logged as HOME below and enter the queue only afterwards, so no double-logging.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nnodes; i++){
+            for (auto veh : nodes[i]->generation_queue){
                 veh->log_data();
             }
         }
+        } // end omp parallel region
+        // Rethrow the deterministic (smallest-id) captured exception, if any.
+        if (gen_exc) std::rethrow_exception(gen_exc);
+        if (run_exc) std::rethrow_exception(run_exc);
 
         // HOME departure pass: vehicles whose departure timestep is now log a HOME entry,
         // transition to WAIT, and enter their origin generation_queue (id ascending).

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -120,7 +120,24 @@ struct Link {
     double kappa;
     double capacity;
     double backward_wave_speed;
-    deque<Vehicle *> vehicles;
+
+    // Vehicle queue as an index-based FIFO ring buffer (replaces deque<Vehicle*>).
+    // veh_ring holds vehicle idx (into World SoA), sized to a power of two.
+    // head_seq/tail_seq are monotonically increasing absolute sequence numbers; the
+    // queue position of a vehicle is (its stored World::veh_queue_seq) - head_seq.
+    vector<int> veh_ring;
+    long long veh_head_seq;
+    long long veh_tail_seq;
+    int veh_ring_mask;
+
+    // Queue helpers. q_at_seq/q_front_idx/q_back_idx return a vehicle idx (into World SoA).
+    int q_size() const { return (int)(veh_tail_seq - veh_head_seq); }
+    bool q_empty() const { return veh_tail_seq == veh_head_seq; }
+    int q_front_idx() const { return veh_ring[veh_head_seq & veh_ring_mask]; }
+    int q_back_idx() const { return veh_ring[(veh_tail_seq - 1) & veh_ring_mask]; }
+    int q_at_seq(long long seq) const { return veh_ring[seq & veh_ring_mask]; }
+    void q_pop_front() { veh_head_seq++; }
+    void q_push(int veh_idx);  // appends veh_idx, records its seq into World::veh_queue_seq
 
     vector<double> traveltime_tt; // increments of time
     vector<double> traveltime_t;
@@ -193,8 +210,14 @@ struct Vehicle {
     // Position in World::vehicles and index into the World SoA hot-state arrays
     int idx;
 
-    Vehicle *leader;
-    Vehicle *follower;
+    // leader/follower are derived from the current link's queue position instead of
+    // being stored: the leader is the vehicle number_of_lanes positions ahead in the
+    // link ring buffer, the follower is number_of_lanes positions behind. Both return
+    // -1 / nullptr when no such vehicle is on the current link.
+    int leader_idx() const;
+    int follower_idx() const;
+    Vehicle *leader() const;
+    Vehicle *follower() const;
 
     // Hot state (x, x_next, x_old, v, move_remain, state, link, lane) lives in
     // World SoA arrays; these facade accessors read/write it by idx.
@@ -328,6 +351,7 @@ struct World {
     vector<int> veh_state;
     vector<int> veh_link_id;  // -1 = not on any link
     vector<int> veh_lane;
+    vector<long long> veh_queue_seq;  // link-ring sequence number at link entry; -1 = not queued
     vector<Link *> links;
     vector<Node *> nodes;
     unordered_map<int, Vehicle *> vehicles_living;  //home, wait, run // vehicles_living[id] = vehicle
@@ -488,3 +512,21 @@ inline int &Vehicle::lane() { return w->veh_lane[idx]; }
 inline int Vehicle::lane() const { return w->veh_lane[idx]; }
 inline Link *Vehicle::link() const { int lid = w->veh_link_id[idx]; return lid >= 0 ? w->links[lid] : nullptr; }
 inline void Vehicle::set_link(Link *ln) { w->veh_link_id[idx] = ln ? ln->id : -1; }
+
+// leader/follower derived from the current link ring buffer (see declarations).
+inline int Vehicle::leader_idx() const {
+    int lid = w->veh_link_id[idx];
+    if (lid < 0) return -1;
+    Link *lk = w->links[lid];
+    long long seq_leader = w->veh_queue_seq[idx] - lk->number_of_lanes;
+    return (seq_leader >= lk->veh_head_seq) ? lk->q_at_seq(seq_leader) : -1;
+}
+inline int Vehicle::follower_idx() const {
+    int lid = w->veh_link_id[idx];
+    if (lid < 0) return -1;
+    Link *lk = w->links[lid];
+    long long seq_follower = w->veh_queue_seq[idx] + lk->number_of_lanes;
+    return (seq_follower < lk->veh_tail_seq) ? lk->q_at_seq(seq_follower) : -1;
+}
+inline Vehicle *Vehicle::leader() const { int li = leader_idx(); return li >= 0 ? w->vehicles[li] : nullptr; }
+inline Vehicle *Vehicle::follower() const { int fi = follower_idx(); return fi >= 0 ? w->vehicles[fi] : nullptr; }

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -332,6 +332,7 @@ struct World {
     bool route_choice_update_gradual;
     bool no_cyclic_routing;
     int instantaneous_TT_timestep_interval = 5;
+    int num_threads = 1;   // OpenMP thread count for parallel regions; -1 = all cores
 
     double delta_t;
     size_t total_timesteps;
@@ -453,6 +454,11 @@ struct World {
     // Update t_max/total_timesteps and resize per-link time-indexed arrays.
     // Must be called before simulation start; the world may be created with a placeholder horizon before the final TMAX is known.
     void set_t_max(double new_t_max);
+
+    // Resolve num_threads into a concrete OpenMP thread count for the num_threads() clause.
+    // -1 means all available cores (omp_get_max_threads(), which honours OMP_NUM_THREADS and
+    // affinity limits). Returns 1 when OpenMP is disabled at build time.
+    int resolve_num_threads() const;
 
     void route_choice_duo();
     void route_choice_duo_gradual();

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -255,11 +255,6 @@ struct Vehicle {
     vector<Link *> links_avoid;
     vector<Link *> specified_route;
 
-    // Reusable buffers for route_next_link_choice() to avoid per-call allocation
-    vector<Link *> _buf_outlinks;
-    vector<Link *> _buf_filtered;
-    vector<double> _buf_outlink_pref;
-
     // Incremental tracking for no_cyclic_routing (O(1) lookup instead of log_link scan)
     vector<bool> _traveled_nodes;       // _traveled_nodes[node_id] = true if visited
     int _traveled_link_count;           // number of distinct links traveled (for specified_route)
@@ -290,6 +285,7 @@ struct Vehicle {
     void route_next_link_choice(const vector<Link*>& linkset);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
+    void reserve_log_arrays();
     void log_data();
     // RUN-state logging with an externally supplied leader spacing (used by the fused
     // RUN system pass, which derives the spacing from the link ring buffer directly).
@@ -370,6 +366,13 @@ struct World {
     double route_choice_uncertainty;
     vector<vector<double>> route_preference;   // route_preference[dest_id][link_id]: preference weight for link towards dest
     vector<char> route_pref_active;            // route_pref_active[dest_id]: true once sum(route_preference[dest]) != 0
+
+    // Shared scratch for Vehicle::route_next_link_choice() (serial: called only from the
+    // single-threaded generate/RUN passes). Moved off Vehicle to cut per-vehicle fixed cost.
+    // To parallelize the RUN pass later, replace these with per-thread/thread_local scratch.
+    vector<Link *> _buf_outlinks;
+    vector<Link *> _buf_filtered;
+    vector<double> _buf_outlink_pref;
 
     // Graph adjacency
     vector<vector<int>> adj_mat;

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -286,13 +286,14 @@ struct Vehicle {
         const string &orig_name,
         const string &dest_name);
 
-    void update();
     void end_trip();
-    void car_follow_newell();
     void route_next_link_choice(const vector<Link*>& linkset);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
     void log_data();
+    // RUN-state logging with an externally supplied leader spacing (used by the fused
+    // RUN system pass, which derives the spacing from the link ring buffer directly).
+    void log_data_run(double spacing);
 
     // Reconstruct log_t / log_state entry i from the scalar counters above.
     double log_t_at(size_t i) const;
@@ -339,8 +340,10 @@ struct World {
 
     // Collections of objects
     vector<Vehicle *> vehicles;         //all state
-    // HOME/WAIT/RUN vehicles in id order; rebuilt per main_loop call, compacted in place each step
-    vector<Vehicle *> update_order;
+    // Departure buckets: departure_buckets[ts] holds vehicle idx (id ascending) whose
+    // first departing timestep is ts. Rebuilt per main_loop call, replacing the old
+    // id-ordered update_order full-scan for HOME->WAIT transitions.
+    vector<vector<int>> departure_buckets;
 
     // Vehicle hot state as SoA arrays, indexed by Vehicle::idx (parallel to `vehicles`)
     vector<double> veh_x;

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -130,6 +130,13 @@ struct Link {
     long long veh_tail_seq;
     int veh_ring_mask;
 
+    // Per-link buffers collecting vehicles that reached this link's end this timestep and
+    // will transfer to a next link. Filled by the RUN pass (this link's exclusive context)
+    // and drained/aggregated into the end_node's incoming_vehicles at the start of
+    // Node::transfer. Replaces the RUN pass pushing directly into the shared node buffer.
+    vector<Vehicle *> arrived_vehicles;
+    vector<Link *> arrived_requests;
+
     // Queue helpers. q_at_seq/q_front_idx/q_back_idx return a vehicle idx (into World SoA).
     int q_size() const { return (int)(veh_tail_seq - veh_head_seq); }
     bool q_empty() const { return veh_tail_seq == veh_head_seq; }
@@ -282,7 +289,7 @@ struct Vehicle {
         const string &dest_name);
 
     void end_trip();
-    void route_next_link_choice(const vector<Link*>& linkset);
+    void route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
     void reserve_log_arrays();
@@ -353,8 +360,6 @@ struct World {
     vector<long long> veh_queue_seq;  // link-ring sequence number at link entry; -1 = not queued
     vector<Link *> links;
     vector<Node *> nodes;
-    unordered_map<int, Vehicle *> vehicles_living;  //home, wait, run // vehicles_living[id] = vehicle
-    unordered_map<int, Vehicle *> vehicles_running; //run
     unordered_map<string, Node *> nodes_map;
     unordered_map<string, Link *> links_map;
     unordered_map<string, Vehicle *> vehicles_map;
@@ -397,15 +402,30 @@ struct World {
     double trips_total;
     double trips_completed;
 
-    // incremental stats accumulators (updated during simulation)
-    double ave_v_sum;
-    double ave_vratio_sum;
-    double stat_sample_count;
-    double trips_completed_count;
+    // Incremental stats accumulators as per-entity partial sums (parallel-safe). RUN-state
+    // samples accumulate on the vehicle's current link; WAIT-state samples on the origin
+    // node. Read back via the id-ordered reductions below so repeated reads are identical.
+    // Indexed by link id (link_*) / node id (node_*), grown in the Link/Node constructors.
+    vector<double> link_ave_v_sum;
+    vector<double> link_ave_vratio_sum;
+    vector<double> link_stat_count;
+    vector<double> link_trips_completed;
+    vector<double> node_stat_count;
 
-    // Randomness
+    // Fixed-order (id-ascending) reductions of the per-entity partial sums above.
+    double ave_v_sum() const;
+    double ave_vratio_sum() const;
+    double stat_sample_count() const;
+    double trips_completed_count() const;
+
+    // Randomness. The single World rng is split into per-node and per-link streams, seeded
+    // deterministically from (random_seed, kind, id) so results are independent of thread
+    // count once Phase 8 parallelizes the per-node/per-link stages. node_rngs: Node::transfer
+    // shuffle + merge lottery and generate-time route_next_link_choice. link_rngs: RUN-path
+    // route_next_link_choice and update_adj_time_matrix per-link noise.
     long long random_seed;
-    std::mt19937 rng;
+    vector<std::mt19937> node_rngs;
+    vector<std::mt19937> link_rngs;
 
     std::ostream *writer;
 

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -372,12 +372,9 @@ struct World {
     vector<vector<double>> route_preference;   // route_preference[dest_id][link_id]: preference weight for link towards dest
     vector<char> route_pref_active;            // route_pref_active[dest_id]: true once sum(route_preference[dest]) != 0
 
-    // Shared scratch for Vehicle::route_next_link_choice() (serial: called only from the
-    // single-threaded generate/RUN passes). Moved off Vehicle to cut per-vehicle fixed cost.
-    // To parallelize the RUN pass later, replace these with per-thread/thread_local scratch.
-    vector<Link *> _buf_outlinks;
-    vector<Link *> _buf_filtered;
-    vector<double> _buf_outlink_pref;
+    // Scratch for Vehicle::route_next_link_choice() lives in thread_local vectors (see
+    // traffi.cpp): the generate pass (per-node) and the RUN pass (per-link) both call it in
+    // parallel, so the scratch must be per-thread rather than a shared World member.
 
     // Graph adjacency
     vector<vector<int>> adj_mat;
@@ -392,7 +389,8 @@ struct World {
     vector<vector<pair<int, double>>> rsa_adj_list;  // adjacency list (rebuilt each call)
     vector<vector<double>> rsa_dist;                 // all-pairs distances
     vector<vector<int>> rsa_next;                    // all-pairs next-hop
-    vector<char> rsa_visited;                        // per-source visited flags
+    // The per-source Dijkstra visited flags and priority queue are thread_local (see
+    // route_search_all): the source loop is parallelized, so this scratch cannot be shared.
 
     bool flag_initialized;
 

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -185,23 +185,36 @@ struct Vehicle {
     double departure_time;
     Node *orig;
     Node *dest;
-    Link *link;
 
     double arrival_time;
     double travel_time;
     double distance_traveled;
 
-    double x;
-    double x_next;
-    double x_old;
-    double v;
-    double move_remain;
-    int lane;
+    // Position in World::vehicles and index into the World SoA hot-state arrays
+    int idx;
 
     Vehicle *leader;
     Vehicle *follower;
 
-    int state; // VehicleState enum: 0=home, 1=wait, 2=run, 3=end, 4=abort
+    // Hot state (x, x_next, x_old, v, move_remain, state, link, lane) lives in
+    // World SoA arrays; these facade accessors read/write it by idx.
+    double &x();
+    double x() const;
+    double &x_next();
+    double x_next() const;
+    double &x_old();
+    double x_old() const;
+    double &v();
+    double v() const;
+    double &move_remain();
+    double move_remain() const;
+    int &state();  // VehicleState enum: 0=home, 1=wait, 2=run, 3=end, 4=abort
+    int state() const;
+    int &lane();
+    int lane() const;
+    Link *link() const;
+    void set_link(Link *ln);
+
     int flag_waiting_for_trip_end;
     int flag_trip_aborted;
     int trip_abort;
@@ -305,6 +318,16 @@ struct World {
     vector<Vehicle *> vehicles;         //all state
     // HOME/WAIT/RUN vehicles in id order; rebuilt per main_loop call, compacted in place each step
     vector<Vehicle *> update_order;
+
+    // Vehicle hot state as SoA arrays, indexed by Vehicle::idx (parallel to `vehicles`)
+    vector<double> veh_x;
+    vector<double> veh_x_next;
+    vector<double> veh_x_old;
+    vector<double> veh_v;
+    vector<double> veh_move_remain;
+    vector<int> veh_state;
+    vector<int> veh_link_id;  // -1 = not on any link
+    vector<int> veh_lane;
     vector<Link *> links;
     vector<Node *> nodes;
     unordered_map<int, Vehicle *> vehicles_living;  //home, wait, run // vehicles_living[id] = vehicle
@@ -444,3 +467,24 @@ struct World {
     CompactFlatLogs build_all_vehicle_logs_flat_compact() const;
 
 };
+
+// -----------------------------------------------------------------------
+// MARK: Vehicle hot-state accessors (SoA facade)
+// -----------------------------------------------------------------------
+
+inline double &Vehicle::x() { return w->veh_x[idx]; }
+inline double Vehicle::x() const { return w->veh_x[idx]; }
+inline double &Vehicle::x_next() { return w->veh_x_next[idx]; }
+inline double Vehicle::x_next() const { return w->veh_x_next[idx]; }
+inline double &Vehicle::x_old() { return w->veh_x_old[idx]; }
+inline double Vehicle::x_old() const { return w->veh_x_old[idx]; }
+inline double &Vehicle::v() { return w->veh_v[idx]; }
+inline double Vehicle::v() const { return w->veh_v[idx]; }
+inline double &Vehicle::move_remain() { return w->veh_move_remain[idx]; }
+inline double Vehicle::move_remain() const { return w->veh_move_remain[idx]; }
+inline int &Vehicle::state() { return w->veh_state[idx]; }
+inline int Vehicle::state() const { return w->veh_state[idx]; }
+inline int &Vehicle::lane() { return w->veh_lane[idx]; }
+inline int Vehicle::lane() const { return w->veh_lane[idx]; }
+inline Link *Vehicle::link() const { int lid = w->veh_link_id[idx]; return lid >= 0 ? w->links[lid] : nullptr; }
+inline void Vehicle::set_link(Link *ln) { w->veh_link_id[idx] = ln ? ln->id : -1; }

--- a/uxsim/trafficpp/utils.h
+++ b/uxsim/trafficpp/utils.h
@@ -7,6 +7,7 @@
 #include <random>
 #include <algorithm>
 #include <map>
+#include <cstdint>
 
 using std::vector, std::cout, std::endl;
 
@@ -22,6 +23,16 @@ inline void remove_from_vector(vector<T *> &vec, T *item) {
     vec.erase(
         std::remove(vec.begin(), vec.end(), item),
         vec.end());
+}
+
+/**
+ * make_entity_rng: build a deterministic per-entity mt19937 stream seeded from the
+ * world seed, an entity-kind tag (node=1, link=2), and the entity id. The stream is a
+ * function of (seed, kind, id) only, so it is independent of node/link insertion order.
+ */
+inline std::mt19937 make_entity_rng(long long seed, unsigned int kind, unsigned int entity_id) {
+    std::seed_seq sq{(std::uint32_t)seed, (std::uint32_t)((std::uint64_t)seed >> 32), (std::uint32_t)kind, (std::uint32_t)entity_id};
+    return std::mt19937(sq);
 }
 
 /**

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -787,7 +787,14 @@ class CppRouteChoice:
 
 
 class CppWorld:
-    """Thin wrapper around C++ World. Delegates simulation to C++ engine."""
+    """Thin wrapper around C++ World. Delegates simulation to C++ engine.
+
+    C++-mode-only argument:
+        threads (int): number of OpenMP threads for the C++ engine. 1 (default)
+            runs single-threaded (the legacy behaviour); N>=1 uses N threads;
+            -1 uses all available cores (honouring OMP_NUM_THREADS and affinity
+            limits). This argument does not exist on the Python-mode World.
+    """
 
     def __init__(self, name="", deltan=5, reaction_time=1,
                  duo_update_time=600, duo_update_weight=0.5, duo_noise=0.01,
@@ -801,7 +808,8 @@ class CppWorld:
                  reduce_memory_delete_vehicle_route_pref=False,
                  hard_deterministic_mode=False,
                  no_cyclic_routing=False,
-                 meta_data=None, user_attribute=None, user_function=None):
+                 meta_data=None, user_attribute=None, user_function=None,
+                 threads=1):
 
         self.W = self  # self-reference for W.W access pattern
         self.rng = np.random.default_rng(seed=random_seed)
@@ -835,6 +843,9 @@ class CppWorld:
         self.name = name
         self.hard_deterministic_mode = hard_deterministic_mode
         self.no_cyclic_routing = no_cyclic_routing
+        if not isinstance(threads, int) or isinstance(threads, bool) or (threads < 1 and threads != -1):
+            raise ValueError(f"threads must be a positive integer or -1 (all cores), got {threads!r}.")
+        self.num_threads = threads
         self.meta_data = meta_data if meta_data is not None else {}
         self.network_info = ddict(list)
         self.demand_info = ddict(list)
@@ -877,6 +888,7 @@ class CppWorld:
         self._cpp_world.route_choice_update_gradual = self.route_choice_update_gradual
         self._cpp_world.no_cyclic_routing = self.no_cyclic_routing
         self._cpp_world.instantaneous_TT_timestep_interval = int(self.instantaneous_TT_timestep_interval)
+        self._cpp_world.num_threads = int(self.num_threads)
 
     # --- Scenario definition ---
 


### PR DESCRIPTION
## Summary

This PR restructures the internals of the C++ engine (`uxsim/trafficpp/`) from pointer-based object-oriented storage (AoS) to a data-oriented core — integer-ID entities, SoA hot-state arrays on `World`, and a state-partitioned main loop — and adds deterministic OpenMP parallelization on top of it. The external interface is fully preserved: all Python-visible attributes, methods, and semantics of `World(cpp=True)` are unchanged, and the existing C++-mode test suite passes without modification.

A new optional `threads` argument controls parallelism explicitly: `World(cpp=True, threads=1)` (default, previous single-thread behavior), `threads=N` for N threads, `threads=-1` for all available cores. Given the same seed, results are bit-identical for any thread count.

## Changes

- **Phase 1**: Vehicle hot state (`x, x_next, x_old, v, move_remain, state, link, lane`) moved to SoA arrays on `World`; `Vehicle` keeps an `idx` and inline facade accessors, so bindings and external code see identical values.
- **Phase 2**: per-link vehicle `deque<Vehicle*>` replaced by an index ring buffer with monotone sequence numbers; `leader`/`follower` pointers and their maintenance code removed and replaced by positional derivation (verified equivalent to the Python semantics site by site).
- **Phase 3**: main loop re-organized into state-partitioned system passes: fused RUN pass in link order (car-following + movement + logging in one sweep), WAIT log pass, HOME departure buckets (no per-step scan of not-yet-departed vehicles), `update_order` removed, `incoming_vehicles` canonicalized to vehicle-id order so merge tie-breaking matches the previous engine.
- **Phase 5**: per-vehicle fixed-cost cuts: `route_preference` allocated lazily (it is unused by the engine; the Python-visible attribute is preserved), log reserves right-sized at departure (realloc-free bound), route-choice scratch buffers shared.
- **Phase 7**: the single global RNG split into per-node and per-link streams, seeded deterministically from `(random_seed, kind, entity_id)`; shared mutable state removed (per-link/per-node statistic partial sums with fixed-order reduction, per-link arrival buffers).
- **Phase 8**: OpenMP parallelization of the entity-exclusive stages (link update, node generate/signal/capacity, fused RUN pass, WAIT pass, all-pairs Dijkstra by source, DUO update by destination) in a single parallel region per timestep. `Node::transfer` intentionally stays serial because it has sequential node-order visibility semantics through shared outgoing-link queues, exactly like the Python implementation.
- **Phase 9**: `threads` argument (C++-mode-only extension in the wrapper; `uxsim.py` untouched). Applied via `num_threads()` clauses; no process-global OpenMP state is modified.

`CMakeLists.txt` (root and `uxsim/trafficpp/`) gains OpenMP; builds without OpenMP still work (pragmas are ignored, `threads` degrades to 1).

## Equivalence and testing

- **RNG-independent scenarios** (deterministic bottleneck/abort/signal/capacity corridors, hard-deterministic merge and grid, chunked execution with mid-run reads and interventions): outputs are **bit-identical** to the previous engine (sha256 over all vehicle logs, link cumulative curves, travel times, and total travel time).
- **Stochastic scenarios**: RNG consumption order changes, so equivalence was validated statistically. New C++ vs Python core (30 vs 10 seeds, 11x11 heavy grid and 8x8 signal grid): all of TTT / completed trips / average speed give Welch p = 0.11–0.86 with mean differences <= 1.8%, and link-volume cross-correlation between modes is at the same level as within-mode seed-to-seed correlation (no systematic difference).
- **Thread-count invariance**: with a fixed seed, outputs are bit-identical for `threads` = 1 / 2 / 8 across all 10 verification scenarios (including stochastic ones).
- **Tests**: `tests/test_cpp_mode.py` 212 passed (211 existing tests unmodified + 1 new test for the `threads` argument).

## Performance

Measured on a single machine, `OMP_NUM_THREADS`/other processes controlled; medians over repeated runs.

vs Python core (single thread, 11x11 grid, deltan=3, tmax=7200, ~59k trips):

| | Python | C++ (this PR) | Speedup |
|---|---|---|---|
| build + exec_simulation | 81.9 s | 2.05 s | **40x** |

vs the pre-refactor C++ engine (single thread):

| Metric | Before | After | Change |
|---|---|---|---|
| heavy grid exec | 2.09 s | 1.81 s | **-13.5%** |
| heavy grid build+exec | 2.20 s | 1.88 s | -14.5% |
| peak RSS / VmPeak | — | — | -75 MB / -417 MB |

Thread scaling (same scenario, `threads` argument):

| threads | C++ main_loop | speedup | exec_simulation | speedup |
|---|---|---|---|---|
| 1 | 1.31 s | 1.0x | 1.99 s | 1.0x |
| 2 | 0.95 s | 1.4x | 1.46 s | 1.4x |
| 4 | 0.67 s | 2.0x | 1.23 s | 1.6x |
| 8 | 0.47 s | **2.8x** | 1.06 s | 1.9x |

`exec_simulation` scaling is diluted by the serial Python-side post-processing (`_sync_from_cpp`, ~0.6 s), which is unchanged in this PR and a candidate for future work.

## Notes for review

- Stochastic realizations for a given seed differ from the previous C++ engine (RNG order/streams changed); deterministic scenarios and hard_deterministic_mode are bit-identical. No test expectations needed adjustment.
- The wrapper change is limited to the new `threads` argument; everything else is engine-internal.

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
