### PR TITLE
Parallelize the C++ engine with deterministic OpenMP while keeping the AoS data layout

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(nanobind CONFIG REQUIRED)
 
+# OpenMP for the deterministic parallel main-loop stages. Not REQUIRED: when it is
+# unavailable the `#pragma omp` directives are ignored and the engine runs serially
+# (the code calls no omp_* runtime functions, only pragmas), so the build still succeeds.
+find_package(OpenMP)
+
 # Python extension module
 # bindings.cpp includes traffi.cpp directly via #include
 nanobind_add_module(uxsim_cpp
@@ -24,6 +29,11 @@ if(MSVC)
     target_compile_options(uxsim_cpp PRIVATE /O2)
 else()
     target_compile_options(uxsim_cpp PRIVATE -O3)
+endif()
+
+# Link OpenMP when available (enables the parallel main-loop stages).
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(uxsim_cpp PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 # Coverage flags (enabled via -DCOVERAGE=ON)

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8717,6 +8717,55 @@ def test_exec_simulation_partial_run_python_cpp_equivalence():
 
 ## misc
 
+def test_threads_parameter():
+    """C++-mode `threads` argument: results must be bit-identical across thread counts, and invalid values must raise ValueError.
+
+    The same seeded grid scenario (route choice active, so the parallel route_search / route_choice / main-loop regions are exercised) is run with threads=1, threads=2 and threads=-1 (all cores). Every vehicle's log_t/log_x/log_v and the total travel time must be exactly equal, confirming the num_threads() clauses preserve determinism regardless of thread count.
+    """
+    def build_and_run(threads):
+        W = World(name="", deltan=5, tmax=1500, print_mode=0, save_mode=0, show_mode=0,
+                  random_seed=42, no_cyclic_routing=True, cpp=True, threads=threads)
+        imax = jmax = 5
+        nodes = {}
+        for i in range(imax):
+            for j in range(jmax):
+                nodes[i, j] = W.addNode(f"n{(i, j)}", i, j)
+        for i in range(imax):
+            for j in range(jmax):
+                if i != imax - 1:
+                    W.addLink(f"l{(i, j, i+1, j)}", nodes[i, j], nodes[i+1, j], length=1000, free_flow_speed=20, jam_density=0.2)
+                if i != 0:
+                    W.addLink(f"l{(i, j, i-1, j)}", nodes[i, j], nodes[i-1, j], length=1000, free_flow_speed=20, jam_density=0.2)
+                if j != jmax - 1:
+                    W.addLink(f"l{(i, j, i, j+1)}", nodes[i, j], nodes[i, j+1], length=1000, free_flow_speed=20, jam_density=0.2)
+                if j != 0:
+                    W.addLink(f"l{(i, j, i, j-1)}", nodes[i, j], nodes[i, j-1], length=1000, free_flow_speed=20, jam_density=0.2)
+        for j in range(jmax):
+            W.adddemand(nodes[0, j], nodes[imax - 1, jmax - 1 - j], 0, 1000, 0.3)
+            W.adddemand(nodes[imax - 1, j], nodes[0, jmax - 1 - j], 0, 1000, 0.3)
+        W.exec_simulation()
+        W.analyzer.basic_analysis()
+        logs = {}
+        for name, veh in W.VEHICLES.items():
+            logs[name] = (list(veh.log_t), list(veh.log_x), list(veh.log_v))
+        return logs, W.analyzer.total_travel_time
+
+    logs1, ttt1 = build_and_run(1)
+    logs2, ttt2 = build_and_run(2)
+    logsN, tttN = build_and_run(-1)
+
+    assert logs1.keys() == logs2.keys() == logsN.keys()
+    for name in logs1:
+        for other in (logs2, logsN):
+            for a, b in zip(logs1[name], other[name]):
+                assert (np.asarray(a) == np.asarray(b)).all(), f"vehicle {name} log mismatch across thread counts"
+    assert ttt1 == ttt2 == tttN
+
+    for bad in (0, -2):
+        with pytest.raises(ValueError):
+            World(name="", tmax=100, print_mode=0, save_mode=0, show_mode=0, cpp=True, threads=bad)
+
+
 def test_access_vehicle_running():
     def create_World(cpp):
         W = World(cpp=cpp,

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -3156,7 +3156,7 @@ def test_route_choice_one_is_too_long_and_another_has_bottleneck():
     assert equal_tolerance(np.average(atts2), 200)
 
 
-def test_route_choice_4route_congestion_avoidance():
+def test_route_choice_4route_congestion_avoidance_multilane():
     tt1s = []
     tt2s = []
     tt3s = []
@@ -8715,8 +8715,6 @@ def test_exec_simulation_partial_run_python_cpp_equivalence():
         assert Wpy.analyzer.trip_completed == Wcpp.analyzer.trip_completed
 
 
-## misc
-
 def test_threads_parameter():
     """C++-mode `threads` argument: results must be bit-identical across thread counts, and invalid values must raise ValueError.
 
@@ -8766,6 +8764,8 @@ def test_threads_parameter():
             World(name="", tmax=100, print_mode=0, save_mode=0, show_mode=0, cpp=True, threads=bad)
 
 
+## misc
+
 def test_access_vehicle_running():
     def create_World(cpp):
         W = World(cpp=cpp,
@@ -8808,3 +8808,4 @@ def test_access_vehicle_running():
 
     assert val1p == val1c
     assert val2p == val2c
+

--- a/uxsim/trafficpp/CMakeLists.txt
+++ b/uxsim/trafficpp/CMakeLists.txt
@@ -8,6 +8,11 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 find_package(nanobind CONFIG REQUIRED)
 
+# OpenMP for the deterministic parallel main-loop stages. Not REQUIRED: when it is
+# unavailable the `#pragma omp` directives are ignored and the engine runs serially
+# (the code calls no omp_* runtime functions, only pragmas), so the build still succeeds.
+find_package(OpenMP)
+
 # Python extension module
 # Note: bindings.cpp includes traffi.cpp directly via #include "traffi.cpp",
 # so we only compile bindings.cpp as the single translation unit.
@@ -25,6 +30,11 @@ if(MSVC)
     target_compile_options(uxsim_cpp PRIVATE /O2)
 else()
     target_compile_options(uxsim_cpp PRIVATE -O3)
+endif()
+
+# Link OpenMP when available (enables the parallel main-loop stages).
+if(OpenMP_CXX_FOUND)
+    target_link_libraries(uxsim_cpp PRIVATE OpenMP::OpenMP_CXX)
 endif()
 
 # Static linking for MinGW

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -542,6 +542,7 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("route_choice_update_gradual", &World::route_choice_update_gradual)
         .def_rw("no_cyclic_routing", &World::no_cyclic_routing)
         .def_rw("instantaneous_TT_timestep_interval", &World::instantaneous_TT_timestep_interval)
+        .def_rw("num_threads", &World::num_threads)
         .def_ro("route_dist", &World::route_dist)
         .def_ro("route_dist_record", &World::route_dist_record)
         .def_ro("route_next", &World::route_next)

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -550,8 +550,8 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("vehicle_log_mode", &World::vehicle_log_mode)
         .def_ro("ave_v", &World::ave_v)
         .def_ro("ave_vratio", &World::ave_vratio)
-        .def_ro("ave_v_sum", &World::ave_v_sum)
-        .def_ro("stat_sample_count", &World::stat_sample_count)
+        .def_prop_ro("ave_v_sum", [](const World &w) { return w.ave_v_sum(); })
+        .def_prop_ro("stat_sample_count", [](const World &w) { return w.stat_sample_count(); })
         .def("set_t_max", &World::set_t_max,
              nb::arg("new_t_max"),
              "Update t_max/total_timesteps and resize per-link time-indexed arrays (call before simulation start)")

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -12,12 +12,19 @@
 #include <algorithm>
 #include <chrono>
 #include <queue>
+#include <climits>
+#include <exception>
 
 #include "traffi.h"
 
 using std::string, std::vector, std::deque, std::pair, std::map, std::unordered_map;
 using std::round, std::floor, std::ceil;
 using std::cout, std::endl;
+
+// Thread-local scratch for the RUN pass front-to-back queue snapshot. The RUN stage is
+// parallelized per-link, so each thread needs its own snapshot buffer; a single main_loop
+// local would race. Reused across links/timesteps to keep its capacity.
+static thread_local vector<Vehicle *> tls_run_snapshot;
 
 // -----------------------------------------------------------------------
 // MARK: Node 
@@ -1179,36 +1186,43 @@ void World::route_search_all(const vector<vector<double>> &adj, double infty) {
         rsa_dist[i].assign(nsize, infty);
         rsa_next[i].assign(nsize, -1);
     }
-    rsa_visited.resize(nsize);
 
     using pdi = pair<double, int>;
-    std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
 
-    // Dijkstra from each source node
-    for (int start = 0; start < nsize; start++) {
-        std::fill(rsa_visited.begin(), rsa_visited.end(), (char)0);
-        auto &dstart = rsa_dist[start];
-        auto &nhstart = rsa_next[start];
-        dstart[start] = 0.0;
-        nhstart[start] = start;
-        pq.push({0.0, start});
+    // Dijkstra from each source node. Each source writes only its own rsa_dist[start] /
+    // rsa_next[start] rows, and rsa_adj_list is read-only here, so the source loop is
+    // parallel-safe with per-thread visited flags and priority queue. The result is
+    // independent of thread count.
+    #pragma omp parallel
+    {
+        vector<char> visited(nsize);
+        std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
+        #pragma omp for schedule(static)
+        for (int start = 0; start < nsize; start++) {
+            std::fill(visited.begin(), visited.end(), (char)0);
+            auto &dstart = rsa_dist[start];
+            auto &nhstart = rsa_next[start];
+            dstart[start] = 0.0;
+            nhstart[start] = start;
+            pq.push({0.0, start});
 
-        while (!pq.empty()) {
-            auto [d, current] = pq.top();
-            pq.pop();
+            while (!pq.empty()) {
+                auto [d, current] = pq.top();
+                pq.pop();
 
-            if (rsa_visited[current]) continue;
-            rsa_visited[current] = 1;
+                if (visited[current]) continue;
+                visited[current] = 1;
 
-            // Explore neighbors via adjacency list
-            double dcur = dstart[current];
-            for (const auto& [next, weight] : rsa_adj_list[current]) {
-                double new_dist = dcur + weight;
-                if (new_dist < dstart[next]) {
-                    dstart[next] = new_dist;
-                    // Update next hop
-                    nhstart[next] = (current == start) ? next : nhstart[current];
-                    pq.push({new_dist, next});
+                // Explore neighbors via adjacency list
+                double dcur = dstart[current];
+                for (const auto& [next, weight] : rsa_adj_list[current]) {
+                    double new_dist = dcur + weight;
+                    if (new_dist < dstart[next]) {
+                        dstart[next] = new_dist;
+                        // Update next hop
+                        nhstart[next] = (current == start) ? next : nhstart[current];
+                        pq.push({new_dist, next});
+                    }
                 }
             }
         }
@@ -1315,7 +1329,13 @@ World::enumerate_k_random_routes_cpp(int k, unsigned int seed){
  * @brief Update route choice using dynamic user optimum.
  */
 void World::route_choice_duo(){
-    for (auto dest : nodes){
+    // Per-destination: route_preference[k] and route_pref_active[k] are exclusive to dest k;
+    // route_next and links are read-only here, so the destination loop is parallel-safe and
+    // independent of thread count.
+    int nnodes = (int)nodes.size();
+    #pragma omp parallel for schedule(static)
+    for (int di = 0; di < nnodes; di++){
+        Node *dest = nodes[di];
         int k = dest->id;
 
         // psum==0.0 iff route_preference[k] has never been reinforced.
@@ -1347,7 +1367,11 @@ void World::route_choice_duo_gradual(){
     // Gradual DUO update: scaled weight applied every timestep
     double weight0 = duo_update_weight * (delta_t / duo_update_time);
 
-    for (auto dest : nodes){
+    // Per-destination and thread-count independent (see route_choice_duo).
+    int nnodes = (int)nodes.size();
+    #pragma omp parallel for schedule(static)
+    for (int di = 0; di < nnodes; di++){
+        Node *dest = nodes[di];
         int k = dest->id;
 
         // psum==0.0 iff route_preference[k] has never been reinforced (see route_choice_duo).
@@ -1496,9 +1520,9 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         }
     }
 
-    // Scratch for the RUN pass: a stable front-to-back snapshot of a link's queue. end_trip()
-    // pops from the live deque during the pass, so we iterate over this snapshot instead.
-    vector<Vehicle *> run_snapshot;
+    // Scratch for the RUN pass (a stable front-to-back snapshot of a link's queue, since
+    // end_trip() pops from the live deque during the pass) lives in a thread_local vector
+    // (tls_run_snapshot) because the RUN stage is parallelized per-link.
 
     for (timestep = start_ts; timestep < end_ts; timestep++){
         time = timestep*delta_t;
@@ -1509,31 +1533,70 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             print_progress_line(time);
         }
 
-        // Link updates
-        for (auto ln : links){
-            ln->update();
+        int nlinks = (int)links.size();
+        int nnodes = (int)nodes.size();
+
+        // All entity-exclusive timestep stages run inside a single parallel region to keep the
+        // OpenMP setup/barrier overhead low (one region per timestep instead of one per stage;
+        // this keeps the 1-thread path lean). Each `omp for` has an implicit barrier, so the
+        // stage order (update -> generate -> transfer -> RUN -> WAIT) and its data dependencies
+        // are preserved. The serial transfer runs in an `omp single`. Exceptions thrown by
+        // route_next_link_choice (specified_route) are captured per stage (smallest entity id
+        // wins, for determinism) and rethrown after the region, since an exception must never
+        // cross the OpenMP boundary.
+        std::exception_ptr gen_exc; int gen_exc_id = INT_MAX;
+        std::exception_ptr run_exc; int run_exc_id = INT_MAX;
+        #pragma omp parallel
+        {
+        // Link updates (per-link): Link::update() touches only its own time-indexed arrays
+        // and capacities, so it is entity-exclusive and independent of thread count.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nlinks; i++){
+            links[i]->update();
         }
 
-        // Node generate + update (matches Python: node.generate() then node.update())
-        for (auto nd : nodes){
-            nd->generate();
+        // Node generate + signal + capacity (per-node): a node's out_links are its exclusive
+        // property (a link has a single start_node), and generate() uses this node's RNG
+        // stream; signal/capacity touch only this node.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nnodes; i++){
+            Node *nd = nodes[i];
+            try {
+                nd->generate();
+            } catch (...) {
+                #pragma omp critical (aos_exc)
+                { if (nd->id < gen_exc_id){ gen_exc_id = nd->id; gen_exc = std::current_exception(); } }
+            }
             nd->signal_update();
             nd->flow_capacity_update();
         }
 
-        // Node transfer
-        for (auto nd : nodes){
-            nd->transfer();
+        // Node transfer: serial. Serial id-ordered node processing has a sequential visibility
+        // semantics (a node's acceptance decisions are seen by later nodes through the shared
+        // out-link queues), matching Python; parallelizing it would break bit identity.
+        #pragma omp single
+        {
+            for (auto nd : nodes){
+                nd->transfer();
+            }
         }
 
         // RUN system pass: a per-link, front-to-back sweep over each link's queue snapshot
-        // that fuses the old car_follow_newell() and update() RUN branch. Each link is
-        // processed independently (no cross-link writes), so this becomes an omp-for later.
+        // that fuses the old car_follow_newell() and update() RUN branch. Parallel per-link: a
+        // vehicle is on exactly one link, so each link touches only its own queue, its own
+        // vehicles' state and logs, its own curves/traveltime events/arrived buffers, its own
+        // per-link stat sums and RNG stream; the result is independent of thread count.
         // Leaders are ahead in the queue (lower index), so they are moved before their
         // followers, matching the old two-phase (car_follow-all then update-all) reads via
         // x_old. Per-link stat sums are hoisted to locals and flushed once after the sweep.
-        for (auto lk : links){
+        // route_next_link_choice may throw (specified_route); capture and rethrow the
+        // smallest-link-id exception after the region.
+        #pragma omp for schedule(static)
+        for (int li = 0; li < nlinks; li++){
+          Link *lk = links[li];
+          try {
             if (lk->vehicles.empty()) continue;
+            vector<Vehicle *> &run_snapshot = tls_run_snapshot;
             run_snapshot.assign(lk->vehicles.begin(), lk->vehicles.end());
             int lanes = lk->number_of_lanes;
             double dpl_dn = lk->delta_per_lane * delta_n;
@@ -1630,16 +1693,27 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             link_ave_v_sum[lk->id] += ave_v_sum_local;
             link_ave_vratio_sum[lk->id] += ave_vratio_sum_local;
             link_stat_count[lk->id] += stat_count_local;
+          } catch (...) {
+            #pragma omp critical (aos_exc)
+            { if (lk->id < run_exc_id){ run_exc_id = lk->id; run_exc = std::current_exception(); } }
+          }
         }
 
-        // WAIT system pass: vehicles still in a generation_queue (those not generated this
-        // step) log a WAIT entry. Vehicles departing this step are logged as HOME below and
-        // enter the queue only afterwards, so they are not double-logged here.
-        for (auto nd : nodes){
-            for (auto veh : nd->generation_queue){
+        // WAIT system pass (per-node): vehicles still in a generation_queue (those not
+        // generated this step) log a WAIT entry. A queued vehicle's origin is this node, so its
+        // WAIT stat sample (node_stat_count[orig->id]) and per-vehicle log are exclusive to
+        // this node; the pass is thread-count independent. Vehicles departing this step are
+        // logged as HOME below and enter the queue only afterwards, so no double-logging.
+        #pragma omp for schedule(static)
+        for (int i = 0; i < nnodes; i++){
+            for (auto veh : nodes[i]->generation_queue){
                 veh->log_data();
             }
         }
+        } // end omp parallel region
+        // Rethrow the deterministic (smallest-id) captured exception, if any.
+        if (gen_exc) std::rethrow_exception(gen_exc);
+        if (run_exc) std::rethrow_exception(run_exc);
 
         // HOME departure pass: vehicles whose departure timestep is now log a HOME entry,
         // transition to WAIT, and enter their origin generation_queue (id ascending).

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -15,6 +15,10 @@
 #include <climits>
 #include <exception>
 
+#ifdef _OPENMP
+#include <omp.h>
+#endif
+
 #include "traffi.h"
 
 using std::string, std::vector, std::deque, std::pair, std::map, std::unordered_map;
@@ -1159,6 +1163,15 @@ void World::update_adj_time_matrix(){
     }
 }
 
+int World::resolve_num_threads() const {
+#ifdef _OPENMP
+    if (num_threads == -1) return omp_get_max_threads();
+    return num_threads;
+#else
+    return 1;
+#endif
+}
+
 void World::route_search_all(const vector<vector<double>> &adj, double infty) {
     int nsize = (int)adj.size();
     if (std::fabs(infty) < 1e-9) {
@@ -1193,7 +1206,7 @@ void World::route_search_all(const vector<vector<double>> &adj, double infty) {
     // rsa_next[start] rows, and rsa_adj_list is read-only here, so the source loop is
     // parallel-safe with per-thread visited flags and priority queue. The result is
     // independent of thread count.
-    #pragma omp parallel
+    #pragma omp parallel num_threads(resolve_num_threads())
     {
         vector<char> visited(nsize);
         std::priority_queue<pdi, vector<pdi>, std::greater<pdi>> pq;
@@ -1333,7 +1346,7 @@ void World::route_choice_duo(){
     // route_next and links are read-only here, so the destination loop is parallel-safe and
     // independent of thread count.
     int nnodes = (int)nodes.size();
-    #pragma omp parallel for schedule(static)
+    #pragma omp parallel for schedule(static) num_threads(resolve_num_threads())
     for (int di = 0; di < nnodes; di++){
         Node *dest = nodes[di];
         int k = dest->id;
@@ -1369,7 +1382,7 @@ void World::route_choice_duo_gradual(){
 
     // Per-destination and thread-count independent (see route_choice_duo).
     int nnodes = (int)nodes.size();
-    #pragma omp parallel for schedule(static)
+    #pragma omp parallel for schedule(static) num_threads(resolve_num_threads())
     for (int di = 0; di < nnodes; di++){
         Node *dest = nodes[di];
         int k = dest->id;
@@ -1546,7 +1559,7 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         // cross the OpenMP boundary.
         std::exception_ptr gen_exc; int gen_exc_id = INT_MAX;
         std::exception_ptr run_exc; int run_exc_id = INT_MAX;
-        #pragma omp parallel
+        #pragma omp parallel num_threads(resolve_num_threads())
         {
         // Link updates (per-link): Link::update() touches only its own time-indexed arrays
         // and capacities, so it is entity-exclusive and independent of thread count.

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -206,7 +206,7 @@ void Node::flow_capacity_update(){
  * @brief Transfer vehicles between links at the node.
  */
 void Node::transfer(){
-    // Aggregate the per-link arrival buffers (filled by the RUN pass) into this node's
+    // Aggregate the per-link arrival buffers (filled by the RUN system pass) into this node's
     // incoming_vehicles. in_links are iterated in a fixed order; sorting by vehicle id below
     // makes the final order independent of the aggregation order, reproducing the id-ordered
     // fill of the original update() loop (which pushed arrivals in vehicle-id order).
@@ -221,7 +221,7 @@ void Node::transfer(){
                   [](Vehicle *a, Vehicle *b){ return a->id < b->id; });
     }
     // incoming_vehicles_requests mirrors incoming_vehicles (request == veh->route_next_link,
-    // set in Vehicle::update and unchanged since). Kept for the observable node member layout.
+    // set in the RUN system pass and unchanged since). Kept for the observable node member layout.
     for (auto veh : incoming_vehicles){
         incoming_vehicles_requests.push_back(veh->route_next_link);
     }
@@ -755,59 +755,6 @@ Vehicle::Vehicle(
 }
 
 /**
- * @brief Update vehicle state and movement.
- */
-void Vehicle::update(){
-
-    if (state == vsHOME){
-        if ((double)w->timestep * w->delta_t >= departure_time){
-            log_data();
-            state = vsWAIT;
-            orig->generation_queue.push_back(this);
-        }
-    }else if (state == vsWAIT){
-        log_data();
-    }else if (state == vsRUN){
-        log_data();
-        if (x == 0.0){
-            route_choice_flag_on_link = 0;
-        }
-
-        v = (x_next - x) / (w->delta_t);
-        x_old = x;
-        x = x_next;
-
-        distance_traveled += x - x_old;
-
-        if (std::fabs(x - link->length) < 1e-9){
-            if (link->end_node == dest){
-                // Prepare for trip end (wait if not at front of link)
-                flag_waiting_for_trip_end = 1;
-                if (link->vehicles.front() == this){
-                    end_trip();
-                }
-            }else if (link->end_node->out_links.empty() && trip_abort == 1){
-                // Dead-end: abort trip
-                flag_trip_aborted = 1;
-                route_next_link = nullptr;
-                flag_waiting_for_trip_end = 1;
-                if (link->vehicles.front() == this){
-                    end_trip();
-                }
-            }else{
-                // RUN-path route choice uses the current link's RNG stream. The arrival is
-                // buffered on this link and aggregated into the end node's incoming_vehicles
-                // at the start of Node::transfer.
-                route_next_link_choice(link->end_node->out_links, w->link_rngs[link->id]);
-                link->arrived_vehicles.push_back(this);
-            }
-        }
-    }else if (state == vsEND || state == vsABORT){
-        // do nothing
-    }
-}
-
-/**
  * @brief End the vehicle's trip.
  */
 void Vehicle::end_trip(){
@@ -846,36 +793,6 @@ void Vehicle::end_trip(){
 
     // Final log entry
     log_data();
-}
-
-/**
- * @brief Apply Newell's car-following model.
- */
-void Vehicle::car_follow_newell(){
-    // free-flow
-    x_next = x + link->vmax * w->delta_t;
-
-    // congested (use delta_per_lane for multi-lane car following)
-    if (leader != nullptr){
-        double gap = leader->x - link->delta_per_lane * w->delta_n;
-        if (gap < x){
-            gap = x;
-        }
-        if (x_next > gap){
-            x_next = gap;
-        }
-    }
-
-    // non-decreasing
-    if (x_next < x){
-        x_next = x;
-    }
-
-    // clamp to link length, carry over residual as move_remain
-    if (x_next > link->length){
-        move_remain = x_next - link->length;
-        x_next = link->length;
-    }
 }
 
 /**
@@ -1564,11 +1481,24 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         return;
     }
 
-    // HOME/WAIT/RUN vehicles in id order; compacted in place each step to drop vehicles that reach END/ABORT (much faster when many have finished).
-    update_order.clear();
+    // Rebuild HOME departure buckets: departure_buckets[ts] holds the HOME vehicles (id
+    // ascending, since `vehicles` is in id order) whose first departing timestep is ts. ts0
+    // is the smallest timestep with (double)ts0*delta_t >= departure_time, using the exact
+    // same FP comparison as the original per-step HOME predicate, then clamped to the chunk
+    // start (past-due vehicles depart on the first step of the chunk).
+    departure_buckets.assign(total_timesteps, {});
     for (auto veh : vehicles){
-        if (veh->state <= vsRUN) update_order.push_back(veh);
+        if (veh->state == vsHOME){
+            int ts0 = (int)(veh->departure_time / delta_t);
+            while ((double)ts0 * delta_t < veh->departure_time) ts0++;
+            if (ts0 < start_ts) ts0 = start_ts;
+            if (ts0 < (int)total_timesteps) departure_buckets[ts0].push_back(veh);
+        }
     }
+
+    // Scratch for the RUN pass: a stable front-to-back snapshot of a link's queue. end_trip()
+    // pops from the live deque during the pass, so we iterate over this snapshot instead.
+    vector<Vehicle *> run_snapshot;
 
     for (timestep = start_ts; timestep < end_ts; timestep++){
         time = timestep*delta_t;
@@ -1596,25 +1526,130 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             nd->transfer();
         }
 
-        // car-following (update_order is in id order, so hard_deterministic semantics hold)
-        for (auto veh : update_order){
-            if (veh->state == vsRUN){
-                veh->car_follow_newell();
+        // RUN system pass: a per-link, front-to-back sweep over each link's queue snapshot
+        // that fuses the old car_follow_newell() and update() RUN branch. Each link is
+        // processed independently (no cross-link writes), so this becomes an omp-for later.
+        // Leaders are ahead in the queue (lower index), so they are moved before their
+        // followers, matching the old two-phase (car_follow-all then update-all) reads via
+        // x_old. Per-link stat sums are hoisted to locals and flushed once after the sweep.
+        for (auto lk : links){
+            if (lk->vehicles.empty()) continue;
+            run_snapshot.assign(lk->vehicles.begin(), lk->vehicles.end());
+            int lanes = lk->number_of_lanes;
+            double dpl_dn = lk->delta_per_lane * delta_n;
+            double vmax_dt = lk->vmax * delta_t;
+            double length = lk->length;
+            double vmax = lk->vmax;
+            int n = (int)run_snapshot.size();
+
+            double ave_v_sum_local = 0.0;
+            double ave_vratio_sum_local = 0.0;
+            double stat_count_local = 0.0;
+
+            for (int i = 0; i < n; i++){
+                Vehicle *veh = run_snapshot[i];
+                // Leader from the pre-pass queue snapshot: a leader that end_trip()'d earlier
+                // in this sweep is still readable here (its x_old is untouched by end_trip).
+                Vehicle *leader = (i - lanes >= 0) ? run_snapshot[i - lanes] : nullptr;
+
+                // car_follow (Newell): self uses its current x, the leader uses x_old (its
+                // pre-move position this step, already stored since it moved first).
+                double self_x = veh->x;
+                double xn = self_x + vmax_dt;
+                if (leader){
+                    double gap = leader->x_old - dpl_dn;
+                    if (gap < self_x) gap = self_x;
+                    if (xn > gap) xn = gap;
+                }
+                if (xn < self_x) xn = self_x;
+                if (xn > length){
+                    veh->move_remain = xn - length;
+                    xn = length;
+                }
+                veh->x_next = xn;
+
+                // log_data (RUN): spacing to the leader reproduces the id-ordered read of the
+                // original update() loop. A lower-id leader moved before self, so self saw its
+                // post-move x (or, if it end_trip()'d, no leader -> -1); a higher-id leader had
+                // not moved when self logged, so self saw its pre-move x (x_old).
+                double spacing = -1.0;
+                if (leader){
+                    if (leader->id < veh->id){
+                        if (leader->state != vsEND && leader->state != vsABORT){
+                            spacing = leader->x - self_x;
+                        }
+                    } else {
+                        spacing = leader->x_old - self_x;
+                    }
+                }
+                // Inline the RUN stat accumulation into link-local sums (flushed once below);
+                // the log push is unchanged from log_data_run().
+                ave_v_sum_local += veh->v;
+                ave_vratio_sum_local += veh->v / vmax;
+                stat_count_local += 1.0;
+                if (vehicle_log_mode){
+                    if (veh->log_size == 0) veh->log_first_ts = (int)timestep;
+                    veh->log_last_ts = (int)timestep;
+                    veh->log_link.push_back(lk->id);
+                    veh->log_x.push_back(self_x);
+                    veh->log_v.push_back(veh->v);
+                    veh->log_lane.push_back(veh->lane);
+                    veh->log_s.push_back(spacing);
+                    veh->log_size++;
+                }
+
+                // move + link-end handling (identical to the old update() RUN branch).
+                if (self_x == 0.0){
+                    veh->route_choice_flag_on_link = 0;
+                }
+                veh->v = (xn - self_x) / delta_t;
+                veh->x_old = self_x;
+                veh->x = xn;
+                veh->distance_traveled += xn - self_x;
+
+                if (std::fabs(xn - length) < 1e-9){
+                    if (lk->end_node == veh->dest){
+                        veh->flag_waiting_for_trip_end = 1;
+                        if (lk->vehicles.front() == veh){
+                            veh->end_trip();
+                        }
+                    } else if (lk->end_node->out_links.empty() && veh->trip_abort == 1){
+                        veh->flag_trip_aborted = 1;
+                        veh->route_next_link = nullptr;
+                        veh->flag_waiting_for_trip_end = 1;
+                        if (lk->vehicles.front() == veh){
+                            veh->end_trip();
+                        }
+                    } else {
+                        veh->route_next_link_choice(lk->end_node->out_links, link_rngs[lk->id]);
+                        lk->arrived_vehicles.push_back(veh);
+                    }
+                }
+            }
+
+            link_ave_v_sum[lk->id] += ave_v_sum_local;
+            link_ave_vratio_sum[lk->id] += ave_vratio_sum_local;
+            link_stat_count[lk->id] += stat_count_local;
+        }
+
+        // WAIT system pass: vehicles still in a generation_queue (those not generated this
+        // step) log a WAIT entry. Vehicles departing this step are logged as HOME below and
+        // enter the queue only afterwards, so they are not double-logged here.
+        for (auto nd : nodes){
+            for (auto veh : nd->generation_queue){
+                veh->log_data();
             }
         }
 
-        // vehicle update, compacting update_order in place (drops END/ABORT vehicles)
-        size_t wpos = 0;
-        for (size_t r = 0; r < update_order.size(); r++){
-            Vehicle *veh = update_order[r];
-            if (veh->state <= vsRUN){
-                veh->update();
-            }
-            if (veh->state <= vsRUN){
-                update_order[wpos++] = veh;
+        // HOME departure pass: vehicles whose departure timestep is now log a HOME entry,
+        // transition to WAIT, and enter their origin generation_queue (id ascending).
+        if (timestep < total_timesteps){
+            for (auto veh : departure_buckets[timestep]){
+                veh->log_data();
+                veh->state = vsWAIT;
+                veh->orig->generation_queue.push_back(veh);
             }
         }
-        update_order.resize(wpos);
 
         // route choice update
         if (route_choice_update_gradual){

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -149,6 +149,9 @@ void Node::generate(){
         generation_queue.pop_front();
 
         veh->state = vsRUN;
+        // Structural parity with Python: a generated vehicle enters VEHICLES_RUNNING. Staged in
+        // this node's buffer (generate runs in the per-node parallel stage) and applied serially.
+        running_gen_buf.push_back(veh);
         veh->link = outlink;
         veh->x = 0.0;
         veh->v = outlink->vmax;  // initial speed at link entry (matches Python)
@@ -763,6 +766,101 @@ Vehicle::Vehicle(
     w->vehicles.push_back(this);
     w->vehicle_id++;
     w->vehicles_map[vehicle_name] = this;
+    // Structural parity with Python: a newly created vehicle is "living" (home) from birth.
+    w->vehicles_living[id] = this;
+}
+
+/**
+ * @brief Apply Newell's car-following model (computes x_next only).
+ *
+ * Mirrors uxsim.py Vehicle.carfollow. Runs as an independent pass before the RUN update pass, so
+ * the leader is read at its pre-move position (leader->x, unchanged this step): the result is
+ * independent of the intra-link processing order and of the OpenMP thread count. The leader is
+ * this->leader (the maintained same-link leader pointer, nullptr once the leader leaves).
+ */
+void Vehicle::car_follow_newell(){
+    // free-flow
+    x_next = x + link->vmax * w->delta_t;
+
+    // congested (use delta_per_lane for multi-lane car following)
+    if (leader != nullptr){
+        double gap = leader->x - link->delta_per_lane * w->delta_n;
+        if (gap < x){
+            gap = x;
+        }
+        if (x_next > gap){
+            x_next = gap;
+        }
+    }
+
+    // non-decreasing
+    if (x_next < x){
+        x_next = x;
+    }
+
+    // clamp to link length, carry over residual as move_remain
+    if (x_next > link->length){
+        move_remain = x_next - link->length;
+        x_next = link->length;
+    }
+}
+
+/**
+ * @brief Update the vehicle's state and position (HOME/WAIT/RUN/END state machine).
+ *
+ * Mirrors uxsim.py Vehicle.update. record_log runs first for every state; the RUN branch then
+ * applies the already-computed x_next, and handles trip end / link transfer at the link end.
+ * snap_leader (the pre-pass queue-position leader) is forwarded to log_data so the RUN-state
+ * leader-spacing reproduces the original id-ordered read even though the RUN pass is per-link.
+ */
+void Vehicle::update(Vehicle *snap_leader){
+    log_data(snap_leader);
+
+    if (state == vsHOME){
+        // depart when the current time reaches the departure time
+        if ((double)w->timestep * w->delta_t >= departure_time){
+            state = vsWAIT;
+            orig->generation_queue.push_back(this);
+        }
+    } else if (state == vsWAIT){
+        // wait in the vertical queue at the origin node (route pref update is World-level in C++)
+    } else if (state == vsRUN){
+        // drive within the link
+        if (x == 0.0){
+            route_choice_flag_on_link = 0;
+        }
+
+        v = (x_next - x) / w->delta_t;
+        x_old = x;
+        x = x_next;
+
+        distance_traveled += x - x_old;
+
+        // at the end of the link
+        if (std::fabs(x - link->length) < 1e-9){
+            if (link->end_node == dest){
+                // prepare for trip end (wait if not at front of link)
+                flag_waiting_for_trip_end = 1;
+                if (link->vehicles.front() == this){
+                    end_trip();
+                }
+            } else if (link->end_node->out_links.empty() && trip_abort == 1){
+                // dead-end: abort trip
+                flag_trip_aborted = 1;
+                route_next_link = nullptr;
+                flag_waiting_for_trip_end = 1;
+                if (link->vehicles.front() == this){
+                    end_trip();
+                }
+            } else {
+                // request link transfer (RUN-path route choice uses this link's RNG stream; the
+                // arrival is staged in this link's buffer, aggregated id-ordered in transfer)
+                route_next_link_choice(link->end_node->out_links, w->link_rngs[link->id]);
+                link->arrived_vehicles.push_back(this);
+            }
+        }
+    }
+    // vsEND / vsABORT: nothing
 }
 
 /**
@@ -787,6 +885,11 @@ void Vehicle::end_trip(){
     arrival_time = (double)w->timestep * w->delta_t;
     travel_time = arrival_time - departure_time;
 
+    // Structural parity with Python's VEHICLES_RUNNING.pop / VEHICLES_LIVING.pop. Staged in this
+    // link's buffer (end_trip runs both in the per-link RUN pass and the serial transfer) and
+    // applied serially post-region, so the shared registries are never mutated concurrently.
+    link->ended_buf.push_back(this);
+
     link->vehicles.pop_front();
 
     if (follower){
@@ -802,7 +905,7 @@ void Vehicle::end_trip(){
         travel_time = -1.0;
     }
 
-    // Final log entry
+    // Final log entry (END/ABORT tail; non-RUN state logs -1s, so no leader spacing needed)
     log_data();
 }
 
@@ -937,7 +1040,7 @@ void Vehicle::record_travel_time(Link *link, double t){
  * Uses reserve'd arrays — push_back is O(1) with no reallocation.
  * log_size tracks actual count (vector::size() is equivalent but log_size avoids any ambiguity if resize was used elsewhere).
  */
-void Vehicle::log_data(){
+void Vehicle::log_data(Vehicle *snap_leader){
     // Accumulate stats for print_simple_results (regardless of log mode).
     // A waiting vehicle counts as a zero-speed sample for the average speed statistic, as in Python's record_log.
     if (state == vsRUN){
@@ -958,11 +1061,26 @@ void Vehicle::log_data(){
         if (state == vsWAIT) log_wait_count++;
         if (state == vsEND || state == vsABORT) log_end_count++;
         if (state == vsRUN){
+            // Leader spacing reproduces the original id-ordered read even though the RUN pass is
+            // per-link front-to-back. snap_leader is the pre-pass queue-position leader: a lower-id
+            // leader was updated before self, so self saw its post-move x (or, if it end_trip()'d,
+            // no leader -> -1); a higher-id leader had not yet moved when self logged in id order,
+            // so self saw its pre-move x (x_old). (Python's record_log reads s.leader.x - s.x.)
+            double spacing = -1.0;
+            if (snap_leader != nullptr){
+                if (snap_leader->id < id){
+                    if (snap_leader->state != vsEND && snap_leader->state != vsABORT){
+                        spacing = snap_leader->x - x;
+                    }
+                } else {
+                    spacing = snap_leader->x_old - x;
+                }
+            }
             log_link.push_back(link ? link->id : -1);
             log_x.push_back(x);
             log_v.push_back(v);
             log_lane.push_back(lane);
-            log_s.push_back((leader != nullptr && leader->link == link) ? leader->x - x : -1.0);
+            log_s.push_back(spacing);
         } else {
             log_link.push_back(-1);
             log_x.push_back(-1);
@@ -1092,6 +1210,8 @@ World::~World(){
     nodes_map.clear();
     links_map.clear();
     vehicles_map.clear();
+    vehicles_living.clear();
+    vehicles_running.clear();
 }
 
 void World::set_t_max(double new_t_max){
@@ -1594,14 +1714,28 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             }
         }
 
-        // RUN system pass: a per-link, front-to-back sweep over each link's queue snapshot
-        // that fuses the old car_follow_newell() and update() RUN branch. Parallel per-link: a
-        // vehicle is on exactly one link, so each link touches only its own queue, its own
-        // vehicles' state and logs, its own curves/traveltime events/arrived buffers, its own
-        // per-link stat sums and RNG stream; the result is independent of thread count.
-        // Leaders are ahead in the queue (lower index), so they are moved before their
-        // followers, matching the old two-phase (car_follow-all then update-all) reads via
-        // x_old. Per-link stat sums are hoisted to locals and flushed once after the sweep.
+        // Car-following pass (per-link): an independent sweep that computes each running
+        // vehicle's x_next (Vehicle::car_follow_newell) before any movement, matching uxsim.py's
+        // separate carfollow loop. Because no vehicle has moved yet, each leader is read at its
+        // pre-move position, so the result is independent of intra-link order and thread count.
+        // A vehicle is on exactly one link, and its leader is on the same link, so per-link is
+        // exclusive. A separate omp for (barrier before the RUN pass) guarantees every x_next is
+        // computed before the RUN pass starts applying movement.
+        #pragma omp for schedule(static)
+        for (int li = 0; li < nlinks; li++){
+            Link *lk = links[li];
+            for (auto veh : lk->vehicles){
+                veh->car_follow_newell();
+            }
+        }
+
+        // RUN update pass (per-link): a front-to-back sweep over each link's queue snapshot that
+        // calls Vehicle::update() (RUN branch: apply x_next, log, handle trip end / transfer).
+        // Parallel per-link: each link touches only its own queue, its own vehicles' state and
+        // logs, its own curves/traveltime events/arrived buffers, its own per-link stat sums and
+        // RNG stream; the result is independent of thread count. The snapshot is stable while
+        // end_trip() pops from the live deque. snap_leader is the pre-pass queue-position leader
+        // (lower index = ahead), forwarded so log_data reproduces the id-ordered spacing read.
         // route_next_link_choice may throw (specified_route); capture and rethrow the
         // smallest-link-id exception after the region.
         #pragma omp for schedule(static)
@@ -1612,100 +1746,12 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
             vector<Vehicle *> &run_snapshot = tls_run_snapshot;
             run_snapshot.assign(lk->vehicles.begin(), lk->vehicles.end());
             int lanes = lk->number_of_lanes;
-            double dpl_dn = lk->delta_per_lane * delta_n;
-            double vmax_dt = lk->vmax * delta_t;
-            double length = lk->length;
-            double vmax = lk->vmax;
             int n = (int)run_snapshot.size();
-
-            double ave_v_sum_local = 0.0;
-            double ave_vratio_sum_local = 0.0;
-            double stat_count_local = 0.0;
-
             for (int i = 0; i < n; i++){
                 Vehicle *veh = run_snapshot[i];
-                // Leader from the pre-pass queue snapshot: a leader that end_trip()'d earlier
-                // in this sweep is still readable here (its x_old is untouched by end_trip).
-                Vehicle *leader = (i - lanes >= 0) ? run_snapshot[i - lanes] : nullptr;
-
-                // car_follow (Newell): self uses its current x, the leader uses x_old (its
-                // pre-move position this step, already stored since it moved first).
-                double self_x = veh->x;
-                double xn = self_x + vmax_dt;
-                if (leader){
-                    double gap = leader->x_old - dpl_dn;
-                    if (gap < self_x) gap = self_x;
-                    if (xn > gap) xn = gap;
-                }
-                if (xn < self_x) xn = self_x;
-                if (xn > length){
-                    veh->move_remain = xn - length;
-                    xn = length;
-                }
-                veh->x_next = xn;
-
-                // log_data (RUN): spacing to the leader reproduces the id-ordered read of the
-                // original update() loop. A lower-id leader moved before self, so self saw its
-                // post-move x (or, if it end_trip()'d, no leader -> -1); a higher-id leader had
-                // not moved when self logged, so self saw its pre-move x (x_old).
-                double spacing = -1.0;
-                if (leader){
-                    if (leader->id < veh->id){
-                        if (leader->state != vsEND && leader->state != vsABORT){
-                            spacing = leader->x - self_x;
-                        }
-                    } else {
-                        spacing = leader->x_old - self_x;
-                    }
-                }
-                // Inline the RUN stat accumulation into link-local sums (flushed once below);
-                // the log push is unchanged from log_data_run().
-                ave_v_sum_local += veh->v;
-                ave_vratio_sum_local += veh->v / vmax;
-                stat_count_local += 1.0;
-                if (vehicle_log_mode){
-                    if (veh->log_size == 0) veh->log_first_ts = (int)timestep;
-                    veh->log_last_ts = (int)timestep;
-                    veh->log_link.push_back(lk->id);
-                    veh->log_x.push_back(self_x);
-                    veh->log_v.push_back(veh->v);
-                    veh->log_lane.push_back(veh->lane);
-                    veh->log_s.push_back(spacing);
-                    veh->log_size++;
-                }
-
-                // move + link-end handling (identical to the old update() RUN branch).
-                if (self_x == 0.0){
-                    veh->route_choice_flag_on_link = 0;
-                }
-                veh->v = (xn - self_x) / delta_t;
-                veh->x_old = self_x;
-                veh->x = xn;
-                veh->distance_traveled += xn - self_x;
-
-                if (std::fabs(xn - length) < 1e-9){
-                    if (lk->end_node == veh->dest){
-                        veh->flag_waiting_for_trip_end = 1;
-                        if (lk->vehicles.front() == veh){
-                            veh->end_trip();
-                        }
-                    } else if (lk->end_node->out_links.empty() && veh->trip_abort == 1){
-                        veh->flag_trip_aborted = 1;
-                        veh->route_next_link = nullptr;
-                        veh->flag_waiting_for_trip_end = 1;
-                        if (lk->vehicles.front() == veh){
-                            veh->end_trip();
-                        }
-                    } else {
-                        veh->route_next_link_choice(lk->end_node->out_links, link_rngs[lk->id]);
-                        lk->arrived_vehicles.push_back(veh);
-                    }
-                }
+                Vehicle *snap_leader = (i - lanes >= 0) ? run_snapshot[i - lanes] : nullptr;
+                veh->update(snap_leader);
             }
-
-            link_ave_v_sum[lk->id] += ave_v_sum_local;
-            link_ave_vratio_sum[lk->id] += ave_vratio_sum_local;
-            link_stat_count[lk->id] += stat_count_local;
           } catch (...) {
             #pragma omp critical (aos_exc)
             { if (lk->id < run_exc_id){ run_exc_id = lk->id; run_exc = std::current_exception(); } }
@@ -1713,14 +1759,15 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         }
 
         // WAIT system pass (per-node): vehicles still in a generation_queue (those not
-        // generated this step) log a WAIT entry. A queued vehicle's origin is this node, so its
-        // WAIT stat sample (node_stat_count[orig->id]) and per-vehicle log are exclusive to
-        // this node; the pass is thread-count independent. Vehicles departing this step are
-        // logged as HOME below and enter the queue only afterwards, so no double-logging.
+        // generated this step) get update() -> log_data() (WAIT branch). A queued vehicle's
+        // origin is this node, so its WAIT stat sample (node_stat_count[orig->id]) and per-vehicle
+        // log are exclusive to this node; the pass is thread-count independent. Vehicles departing
+        // this step are logged as HOME below and enter the queue only afterwards, so no
+        // double-logging.
         #pragma omp for schedule(static)
         for (int i = 0; i < nnodes; i++){
             for (auto veh : nodes[i]->generation_queue){
-                veh->log_data();
+                veh->update();
             }
         }
         } // end omp parallel region
@@ -1728,14 +1775,36 @@ void World::main_loop(double duration_t=-1, double until_t=-1){
         if (gen_exc) std::rethrow_exception(gen_exc);
         if (run_exc) std::rethrow_exception(run_exc);
 
-        // HOME departure pass: vehicles whose departure timestep is now log a HOME entry,
-        // transition to WAIT, and enter their origin generation_queue (id ascending).
+        // HOME departure pass (serial): vehicles whose departure timestep is now get update()
+        // -> log_data() (HOME entry) and the HOME branch transitions them to WAIT and appends
+        // them to their origin generation_queue (id ascending, since `vehicles` is in id order).
+        // Run after the WAIT pass so a vehicle departing this step is not logged twice.
         if (timestep < total_timesteps){
             for (auto veh : departure_buckets[timestep]){
-                veh->log_data();
-                veh->state = vsWAIT;
-                veh->orig->generation_queue.push_back(veh);
+                veh->update();
             }
+        }
+
+        // Reconcile the VEHICLES_LIVING / VEHICLES_RUNNING registries: replay the per-node
+        // running-insert buffers (from generate) and the per-link end-trip buffers (from the RUN
+        // pass and transfer) that were staged to avoid concurrent mutation of the shared maps.
+        // Inserts first, then erases, so a vehicle generated and ended in the same step ends up
+        // absent, matching the mid-step insert/erase order in Python. Applied in node/link id
+        // order; membership at step end matches the original per-vehicle mutation.
+        for (int i = 0; i < nnodes; i++){
+            Node *nd = nodes[i];
+            for (auto veh : nd->running_gen_buf){
+                vehicles_running[veh->id] = veh;
+            }
+            nd->running_gen_buf.clear();
+        }
+        for (int li = 0; li < nlinks; li++){
+            Link *lk = links[li];
+            for (auto veh : lk->ended_buf){
+                vehicles_running.erase(veh->id);
+                vehicles_living.erase(veh->id);
+            }
+            lk->ended_buf.clear();
         }
 
         // route choice update

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -44,6 +44,9 @@ Node::Node(World *w, const string &node_name, double x, double y, vector<double>
       flow_capacity(flow_capacity),
       number_of_lanes(number_of_lanes){
     w->nodes.push_back(this);
+    // Per-node RNG stream (kind=1) and stat partial sum, seeded/sized by node id.
+    w->node_rngs.push_back(make_entity_rng(w->random_seed, 1u, (unsigned int)id));
+    w->node_stat_count.push_back(0.0);
     w->node_id++;
     w->nodes_map[node_name] = this;
 
@@ -105,8 +108,8 @@ void Node::generate(){
         }
         Vehicle *veh = generation_queue.front();
 
-        // Choose the next link
-        veh->route_next_link_choice(out_links);
+        // Choose the next link (generate uses this node's RNG stream)
+        veh->route_next_link_choice(out_links, w->node_rngs[id]);
 
         if (veh->route_next_link == nullptr){
             break;
@@ -147,8 +150,6 @@ void Node::generate(){
         }
         veh->_traveled_nodes[outlink->start_node->id] = true;
         veh->_traveled_link_count++;
-
-        w->vehicles_running[veh->id] = veh;
 
         // Lane assignment
         if (!outlink->vehicles.empty()){
@@ -205,6 +206,26 @@ void Node::flow_capacity_update(){
  * @brief Transfer vehicles between links at the node.
  */
 void Node::transfer(){
+    // Aggregate the per-link arrival buffers (filled by the RUN pass) into this node's
+    // incoming_vehicles. in_links are iterated in a fixed order; sorting by vehicle id below
+    // makes the final order independent of the aggregation order, reproducing the id-ordered
+    // fill of the original update() loop (which pushed arrivals in vehicle-id order).
+    for (auto inlink : in_links){
+        for (auto veh : inlink->arrived_vehicles){
+            incoming_vehicles.push_back(veh);
+        }
+        inlink->arrived_vehicles.clear();
+    }
+    if (incoming_vehicles.size() > 1){
+        std::sort(incoming_vehicles.begin(), incoming_vehicles.end(),
+                  [](Vehicle *a, Vehicle *b){ return a->id < b->id; });
+    }
+    // incoming_vehicles_requests mirrors incoming_vehicles (request == veh->route_next_link,
+    // set in Vehicle::update and unchanged since). Kept for the observable node member layout.
+    for (auto veh : incoming_vehicles){
+        incoming_vehicles_requests.push_back(veh->route_next_link);
+    }
+
     // Build outlink list with repetition per lane (multi-lane gets more transfer attempts)
     _buf_outlinks_expanded.clear();
     _buf_seen_outlinks.clear();
@@ -224,7 +245,7 @@ void Node::transfer(){
     if (!w->hard_deterministic_mode){
         for (int i = (int)outlinks_expanded.size() - 1; i > 0; i--){
             std::uniform_int_distribution<int> dist(0, i);
-            int j = dist(w->rng);
+            int j = dist(w->node_rngs[id]);
             std::swap(outlinks_expanded[i], outlinks_expanded[j]);
         }
     }
@@ -282,7 +303,7 @@ void Node::transfer(){
             chosen_veh = random_choice<Vehicle>(
                 merging_vehs,
                 merge_priorities,
-                w->rng);
+                w->node_rngs[id]);
         }
         if (!chosen_veh){
             continue;
@@ -474,6 +495,12 @@ Link::Link(
     end_node->in_links.push_back(this);
 
     w->links.push_back(this);
+    // Per-link RNG stream (kind=2) and stat partial sums, seeded/sized by link id.
+    w->link_rngs.push_back(make_entity_rng(w->random_seed, 2u, (unsigned int)id));
+    w->link_ave_v_sum.push_back(0.0);
+    w->link_ave_vratio_sum.push_back(0.0);
+    w->link_stat_count.push_back(0.0);
+    w->link_trips_completed.push_back(0.0);
     w->link_id++;
     w->links_map[link_name] = this;
 }
@@ -723,7 +750,6 @@ Vehicle::Vehicle(
     }
 
     w->vehicles.push_back(this);
-    w->vehicles_living[id] = this;
     w->vehicle_id++;
     w->vehicles_map[vehicle_name] = this;
 }
@@ -769,9 +795,11 @@ void Vehicle::update(){
                     end_trip();
                 }
             }else{
-                route_next_link_choice(link->end_node->out_links);
-                link->end_node->incoming_vehicles.push_back(this);
-                link->end_node->incoming_vehicles_requests.push_back(route_next_link);
+                // RUN-path route choice uses the current link's RNG stream. The arrival is
+                // buffered on this link and aggregated into the end node's incoming_vehicles
+                // at the start of Node::transfer.
+                route_next_link_choice(link->end_node->out_links, w->link_rngs[link->id]);
+                link->arrived_vehicles.push_back(this);
             }
         }
     }else if (state == vsEND || state == vsABORT){
@@ -784,7 +812,8 @@ void Vehicle::update(){
  */
 void Vehicle::end_trip(){
     state = vsEND;
-    w->trips_completed_count += 1.0;
+    // Per-link completed-trip counter (end_trip runs in this link's exclusive context).
+    w->link_trips_completed[link->id] += 1.0;
     link->departure_curve[w->timestep] += w->delta_n;
 
     // Record traveltime_real event (lazily materialized on read, matching Python's traveltime_actual slice update)
@@ -799,9 +828,6 @@ void Vehicle::end_trip(){
 
     arrival_time = (double)w->timestep * w->delta_t;
     travel_time = arrival_time - departure_time;
-
-    w->vehicles_living.erase(id);
-    w->vehicles_running.erase(id);
 
     link->vehicles.pop_front();
 
@@ -857,7 +883,7 @@ void Vehicle::car_follow_newell(){
  * 
  * @param linkset Available links to choose from.
  */
-void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
+void Vehicle::route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng){
     if (linkset.empty()){
         route_next_link = nullptr;
         route_choice_flag_on_link = 1;
@@ -953,7 +979,7 @@ void Vehicle::route_next_link_choice(const vector<Link*>& linkset){
         route_next_link = random_choice<Link>(
             outlinks,
             outlink_pref,
-            w->rng);
+            rng);
     }
     route_choice_flag_on_link = 1;
 }
@@ -987,13 +1013,15 @@ void Vehicle::log_data(){
     // Accumulate stats for print_simple_results (regardless of log mode).
     // A waiting vehicle counts as a zero-speed sample for the average speed statistic, as in Python's record_log.
     if (state == vsRUN){
-        w->ave_v_sum += v;
+        // RUN samples accumulate on the current link's partial sums.
         if (link){
-            w->ave_vratio_sum += v / link->vmax;
+            w->link_ave_v_sum[link->id] += v;
+            w->link_ave_vratio_sum[link->id] += v / link->vmax;
+            w->link_stat_count[link->id] += 1.0;
         }
-        w->stat_sample_count += 1.0;
     } else if (state == vsWAIT){
-        w->stat_sample_count += 1.0;
+        // WAIT samples accumulate on the origin node (where the vehicle queues).
+        w->node_stat_count[orig->id] += 1.0;
     }
 
     if (w->vehicle_log_mode){
@@ -1112,11 +1140,6 @@ World::World(
       ave_vratio(0.0),
       trips_total(0.0),
       trips_completed(0.0),
-      ave_v_sum(0.0),
-      ave_vratio_sum(0.0),
-      stat_sample_count(0.0),
-      trips_completed_count(0.0),
-      rng((std::mt19937::result_type)random_seed),
       flag_initialized(false),
       writer(&std::cout){
     // The route update interval has a minimum of 1 timestep, like Python's DELTAT_ROUTE.
@@ -1138,8 +1161,6 @@ World::~World(){
     vehicles.clear();
     links.clear();
     nodes.clear();
-    vehicles_living.clear();
-    vehicles_running.clear();
     nodes_map.clear();
     links_map.clear();
     vehicles_map.clear();
@@ -1200,7 +1221,7 @@ void World::update_adj_time_matrix(){
         if (hard_deterministic_mode){
             new_link_tt = tt + penalty;
         } else {
-            double noise_factor = random_range_float64(1.0, 1.0 + noise, rng);
+            double noise_factor = random_range_float64(1.0, 1.0 + noise, link_rngs[ln->id]);
             new_link_tt = tt * noise_factor + penalty;
         }
         // If there are multiple links between the same nodes, average the travel time
@@ -1449,13 +1470,38 @@ void World::print_scenario_stats(){
     }
 }
 
+// Id-ordered reductions of the per-entity statistic partial sums. Summation is over index
+// (== entity id) in ascending order so repeated reads are bit-identical.
+double World::ave_v_sum() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_ave_v_sum.size(); i++) s += link_ave_v_sum[i];
+    return s;
+}
+double World::ave_vratio_sum() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_ave_vratio_sum.size(); i++) s += link_ave_vratio_sum[i];
+    return s;
+}
+double World::stat_sample_count() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_stat_count.size(); i++) s += link_stat_count[i];
+    for (size_t i = 0; i < node_stat_count.size(); i++) s += node_stat_count[i];
+    return s;
+}
+double World::trips_completed_count() const {
+    double s = 0.0;
+    for (size_t i = 0; i < link_trips_completed.size(); i++) s += link_trips_completed[i];
+    return s;
+}
+
 void World::print_simple_results(){
     // Compute from incrementally accumulated stats (no log scan needed)
     trips_total = (double)vehicles.size() * delta_n;
-    trips_completed = trips_completed_count * delta_n;
-    if (stat_sample_count > 0){
-        ave_v = ave_v_sum / stat_sample_count;
-        ave_vratio = ave_vratio_sum / stat_sample_count;
+    trips_completed = trips_completed_count() * delta_n;
+    double n_samples = stat_sample_count();
+    if (n_samples > 0){
+        ave_v = ave_v_sum() / n_samples;
+        ave_vratio = ave_vratio_sum() / n_samples;
     }
 
     (*writer) << "Stats:\n";

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -62,6 +62,12 @@ struct Node {
     // Vehicles waiting to be generated onto the outgoing link
     deque<Vehicle *> generation_queue;
 
+    // Per-node buffer recording vehicles that entered the RUN state via generate() this
+    // timestep (their World::vehicles_running insert). generate() runs in the per-node parallel
+    // stage, so the insert into the shared registry is deferred here and applied in id order in
+    // the serial post-region reconciliation (see main_loop).
+    vector<Vehicle *> running_gen_buf;
+
     double x;
     double y;
 
@@ -142,6 +148,12 @@ struct Link {
     // Node::transfer. Replaces the RUN pass pushing directly into the shared node buffer, so
     // per-link stages can run independently once parallelized.
     vector<Vehicle *> arrived_vehicles;
+
+    // Per-link buffer recording vehicles that ended their trip on this link this timestep (their
+    // World::vehicles_living / vehicles_running erase). end_trip() runs in the per-link RUN pass
+    // (parallel) and in the serial transfer; both defer the shared-registry erase here, applied
+    // in id order in the serial post-region reconciliation (see main_loop).
+    vector<Vehicle *> ended_buf;
 
     double capacity_out;
     double capacity_out_remain;
@@ -258,10 +270,18 @@ struct Vehicle {
         const string &dest_name);
 
     void end_trip();
+    // Newell car-following: computes x_next only (no state change), read as an independent pass
+    // before the RUN update pass so leaders are read at their pre-move position (order-neutral).
+    void car_follow_newell();
+    // update() drives the HOME/WAIT/RUN/END state machine (structural parity with Python's
+    // Vehicle.update). snap_leader is the pre-pass queue-position leader supplied by the RUN
+    // pass so log_data() can reproduce the id-ordered leader-spacing read; nullptr for the
+    // WAIT/HOME passes and the end_trip tail entry.
+    void update(Vehicle *snap_leader = nullptr);
     void route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
-    void log_data();
+    void log_data(Vehicle *snap_leader = nullptr);
 
     // Reconstruct log_t / log_state entry i from the scalar counters above.
     double log_t_at(size_t i) const;
@@ -320,6 +340,16 @@ struct World {
     unordered_map<string, Node *> nodes_map;
     unordered_map<string, Link *> links_map;
     unordered_map<string, Vehicle *> vehicles_map;
+
+    // Live-vehicle registries, restored for structural parity with Python's VEHICLES_LIVING /
+    // VEHICLES_RUNNING (same membership semantics: living = home|wait|run, running = run).
+    // Populated at Vehicle construction (living) and Node::generate (running); entries removed
+    // in Vehicle::end_trip. Not exposed to bindings (read-out is zero); maintained so future
+    // feature ports keep line-by-line correspondence with uxsim.py. Mutations from the parallel
+    // generate/RUN stages are staged in Node::running_gen_buf / Link::ended_buf and applied in
+    // the serial post-region reconciliation, so the shared maps are never touched concurrently.
+    unordered_map<int, Vehicle *> vehicles_living;   // home, wait, run
+    unordered_map<int, Vehicle *> vehicles_running;  // run
 
     size_t timestep;    //simulation timestep
     double time;    //simulation time in second

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -136,6 +136,13 @@ struct Link {
 
     double merge_priority;
 
+    // Per-link buffer collecting vehicles that reached this link's end this timestep and
+    // will transfer to a next link. Filled by the RUN pass (Vehicle::update, this link's
+    // exclusive context) and drained/aggregated into the end_node's incoming_vehicles at the
+    // start of Node::transfer. Replaces the RUN pass pushing directly into the shared node
+    // buffer, so per-link stages can run independently once parallelized.
+    vector<Vehicle *> arrived_vehicles;
+
     double capacity_out;
     double capacity_out_remain;
     double capacity_in;
@@ -253,7 +260,7 @@ struct Vehicle {
     void update();
     void end_trip();
     void car_follow_newell();
-    void route_next_link_choice(const vector<Link*>& linkset);
+    void route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
     void log_data();
@@ -307,8 +314,6 @@ struct World {
     vector<Vehicle *> update_order;
     vector<Link *> links;
     vector<Node *> nodes;
-    unordered_map<int, Vehicle *> vehicles_living;  //home, wait, run // vehicles_living[id] = vehicle
-    unordered_map<int, Vehicle *> vehicles_running; //run
     unordered_map<string, Node *> nodes_map;
     unordered_map<string, Link *> links_map;
     unordered_map<string, Vehicle *> vehicles_map;
@@ -344,15 +349,30 @@ struct World {
     double trips_total;
     double trips_completed;
 
-    // incremental stats accumulators (updated during simulation)
-    double ave_v_sum;
-    double ave_vratio_sum;
-    double stat_sample_count;
-    double trips_completed_count;
+    // Incremental stats accumulators as per-entity partial sums (parallel-safe). RUN-state
+    // samples accumulate on the vehicle's current link; WAIT-state samples on the origin
+    // node. Read back via the id-ordered reductions below so repeated reads are identical.
+    // Indexed by link id (link_*) / node id (node_*), grown in the Link/Node constructors.
+    vector<double> link_ave_v_sum;
+    vector<double> link_ave_vratio_sum;
+    vector<double> link_stat_count;
+    vector<double> link_trips_completed;
+    vector<double> node_stat_count;
 
-    // Randomness
+    // Fixed-order (id-ascending) reductions of the per-entity partial sums above.
+    double ave_v_sum() const;
+    double ave_vratio_sum() const;
+    double stat_sample_count() const;
+    double trips_completed_count() const;
+
+    // Randomness. The single World rng is split into per-node and per-link streams, seeded
+    // deterministically from (random_seed, kind, id) so results are independent of thread
+    // count once the per-node/per-link stages are parallelized. node_rngs: Node::transfer
+    // shuffle + merge lottery and generate-time route_next_link_choice. link_rngs: RUN-path
+    // route_next_link_choice and update_adj_time_matrix per-link noise.
     long long random_seed;
-    std::mt19937 rng;
+    vector<std::mt19937> node_rngs;
+    vector<std::mt19937> link_rngs;
 
     std::ostream *writer;
 

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -297,6 +297,7 @@ struct World {
     bool route_choice_update_gradual;
     bool no_cyclic_routing;
     int instantaneous_TT_timestep_interval = 5;
+    int num_threads = 1;   // OpenMP thread count for parallel regions; -1 = all cores
 
     double delta_t;
     size_t total_timesteps;
@@ -405,6 +406,11 @@ struct World {
     // Update t_max/total_timesteps and resize per-link time-indexed arrays.
     // Must be called before simulation start; the world may be created with a placeholder horizon before the final TMAX is known.
     void set_t_max(double new_t_max);
+
+    // Resolve num_threads into a concrete OpenMP thread count for the num_threads() clause.
+    // -1 means all available cores (omp_get_max_threads(), which honours OMP_NUM_THREADS and
+    // affinity limits). Returns 1 when OpenMP is disabled at build time.
+    int resolve_num_threads() const;
 
     void route_choice_duo();
     void route_choice_duo_gradual();

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -341,7 +341,8 @@ struct World {
     vector<vector<pair<int, double>>> rsa_adj_list;  // adjacency list (rebuilt each call)
     vector<vector<double>> rsa_dist;                 // all-pairs distances
     vector<vector<int>> rsa_next;                    // all-pairs next-hop
-    vector<char> rsa_visited;                        // per-source visited flags
+    // The per-source Dijkstra visited flags and priority queue are thread_local (see
+    // route_search_all): the source loop is parallelized, so this scratch cannot be shared.
 
     bool flag_initialized;
 

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -137,10 +137,10 @@ struct Link {
     double merge_priority;
 
     // Per-link buffer collecting vehicles that reached this link's end this timestep and
-    // will transfer to a next link. Filled by the RUN pass (Vehicle::update, this link's
-    // exclusive context) and drained/aggregated into the end_node's incoming_vehicles at the
-    // start of Node::transfer. Replaces the RUN pass pushing directly into the shared node
-    // buffer, so per-link stages can run independently once parallelized.
+    // will transfer to a next link. Filled by the RUN system pass (this link's exclusive
+    // context) and drained/aggregated into the end_node's incoming_vehicles at the start of
+    // Node::transfer. Replaces the RUN pass pushing directly into the shared node buffer, so
+    // per-link stages can run independently once parallelized.
     vector<Vehicle *> arrived_vehicles;
 
     double capacity_out;
@@ -257,9 +257,7 @@ struct Vehicle {
         const string &orig_name,
         const string &dest_name);
 
-    void update();
     void end_trip();
-    void car_follow_newell();
     void route_next_link_choice(const vector<Link*>& linkset, std::mt19937 &rng);
     void enforce_route(vector<Link*> route);
     void record_travel_time(Link *link, double t);
@@ -310,8 +308,12 @@ struct World {
 
     // Collections of objects
     vector<Vehicle *> vehicles;         //all state
-    // HOME/WAIT/RUN vehicles in id order; rebuilt per main_loop call, compacted in place each step
-    vector<Vehicle *> update_order;
+    // HOME departure schedule: departure_buckets[ts] holds the HOME vehicles (id ascending,
+    // since `vehicles` is in id order) whose first departing timestep is ts. Rebuilt per
+    // main_loop call; replaces the old id-ordered update_order full-scan for the HOME->WAIT
+    // transition. The RUN/WAIT stages find their vehicles via the per-link deques and the
+    // per-node generation_queues, so no global update order is needed.
+    vector<vector<Vehicle *>> departure_buckets;
     vector<Link *> links;
     vector<Node *> nodes;
     unordered_map<string, Node *> nodes_map;

--- a/uxsim/trafficpp/utils.h
+++ b/uxsim/trafficpp/utils.h
@@ -7,6 +7,7 @@
 #include <random>
 #include <algorithm>
 #include <map>
+#include <cstdint>
 
 using std::vector, std::cout, std::endl;
 
@@ -22,6 +23,16 @@ inline void remove_from_vector(vector<T *> &vec, T *item) {
     vec.erase(
         std::remove(vec.begin(), vec.end(), item),
         vec.end());
+}
+
+/**
+ * make_entity_rng: build a deterministic per-entity mt19937 stream seeded from the
+ * world seed, an entity-kind tag (node=1, link=2), and the entity id. The stream is a
+ * function of (seed, kind, id) only, so it is independent of node/link insertion order.
+ */
+inline std::mt19937 make_entity_rng(long long seed, unsigned int kind, unsigned int entity_id) {
+    std::seed_seq sq{(std::uint32_t)seed, (std::uint32_t)((std::uint64_t)seed >> 32), (std::uint32_t)kind, (std::uint32_t)entity_id};
+    return std::mt19937(sq);
 }
 
 /**

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -787,7 +787,14 @@ class CppRouteChoice:
 
 
 class CppWorld:
-    """Thin wrapper around C++ World. Delegates simulation to C++ engine."""
+    """Thin wrapper around C++ World. Delegates simulation to C++ engine.
+
+    C++-mode-only argument:
+        threads (int): number of OpenMP threads for the C++ engine. 1 (default)
+            runs single-threaded (the legacy behaviour); N>=1 uses N threads;
+            -1 uses all available cores (honouring OMP_NUM_THREADS and affinity
+            limits). This argument does not exist on the Python-mode World.
+    """
 
     def __init__(self, name="", deltan=5, reaction_time=1,
                  duo_update_time=600, duo_update_weight=0.5, duo_noise=0.01,
@@ -801,7 +808,8 @@ class CppWorld:
                  reduce_memory_delete_vehicle_route_pref=False,
                  hard_deterministic_mode=False,
                  no_cyclic_routing=False,
-                 meta_data=None, user_attribute=None, user_function=None):
+                 meta_data=None, user_attribute=None, user_function=None,
+                 threads=1):
 
         self.W = self  # self-reference for W.W access pattern
         self.rng = np.random.default_rng(seed=random_seed)
@@ -835,6 +843,9 @@ class CppWorld:
         self.name = name
         self.hard_deterministic_mode = hard_deterministic_mode
         self.no_cyclic_routing = no_cyclic_routing
+        if not isinstance(threads, int) or isinstance(threads, bool) or (threads < 1 and threads != -1):
+            raise ValueError(f"threads must be a positive integer or -1 (all cores), got {threads!r}.")
+        self.num_threads = threads
         self.meta_data = meta_data if meta_data is not None else {}
         self.network_info = ddict(list)
         self.demand_info = ddict(list)
@@ -877,6 +888,7 @@ class CppWorld:
         self._cpp_world.route_choice_update_gradual = self.route_choice_update_gradual
         self._cpp_world.no_cyclic_routing = self.no_cyclic_routing
         self._cpp_world.instantaneous_TT_timestep_interval = int(self.instantaneous_TT_timestep_interval)
+        self._cpp_world.num_threads = int(self.num_threads)
 
     # --- Scenario definition ---
 


### PR DESCRIPTION
## Summary

This PR adds deterministic OpenMP parallelization to the C++ engine **while keeping the existing AoS data layout** (Vehicle/Link/Node classes, per-link vehicle deques, leader/follower pointers are all unchanged). It is an alternative to #340: it delivers the same parallelization benefits (and better scaling) without the full SoA/ECS refactor, so the two PRs are mutually exclusive. If this one is adopted, #340 should be closed.

To keep future feature-tracking against `uxsim.py` straightforward, the engine deliberately preserves method-level structural parity with the Python implementation: `Vehicle::update()`, `Vehicle::car_follow_newell()`, `Vehicle::log_data()`, `Vehicle::end_trip()`, and the `vehicles_living`/`vehicles_running` registries all remain and correspond one-to-one to their `uxsim.py` counterparts (`Vehicle.update`, `Vehicle.carfollow`, `Vehicle.record_log`, `Vehicle.end_trip`, `W.VEHICLES_LIVING`/`VEHICLES_RUNNING`).

Usage: `W = World(cpp=True, threads=N)` (default 1; `-1` = all cores). `uxsim.py` itself is unchanged; the `threads` argument is a cpp-mode-only extension of the wrapper.

## Design

- **Per-entity RNG streams** (commit 1): the single shared `mt19937` is split into per-node streams (transfer shuffle/merge lottery, route choice at generation) and per-link streams (route choice at link end, adjacency travel-time noise), each seeded deterministically from `{seed, kind, id}`. Shared mutable state is removed: global statistics become per-link/per-node partial sums reduced in id order, and `incoming_vehicles` is collected per link and aggregated in vehicle-id order at the start of `transfer`.
- **Stage-partitioned main loop** (commits 2 and 5): the id-ordered mixed-state vehicle update pass is restructured into a per-link car-following pass (`Vehicle::car_follow_newell()`, computes `x_next` only, order-independent), a per-link RUN update pass (front-to-back over each link's deque, calling `Vehicle::update()`), a per-node WAIT logging pass, and a departure-bucket HOME pass. The id-order-dependent semantics of the old scan are reproduced bit-exactly via the discriminant rule for the spacing log (`leader_id < self_id ? post-move x : pre-move x`; `-1` if the lower-id leader ended its trip in the same step). The `vehicles_living`/`vehicles_running` registries are maintained exactly as before: transitions are staged in per-node/per-link buffers during parallel stages and applied in id order in a serial reconciliation step, so their contents at the end of each timestep match the serial (and Python) semantics.
- **Deterministic OpenMP parallelization** (commit 3): each timestep runs in a single `omp parallel` region with per-stage `omp for schedule(static)` loops (links, node generate/signal/capacity, car-follow, RUN pass, WAIT pass). `Node::transfer` stays serial inside `omp single` because it has sequential-visibility semantics identical to the Python version. Route search / DUO choice are parallelized per source / per destination. Exceptions thrown inside parallel regions are captured and deterministically rethrown (lowest entity id wins). `omp_set_num_threads` is never called; thread counts are passed via `num_threads()` clauses only.
- **`threads` parameter** (commit 4): validation (bool rejected, `ValueError` for 0 or ≤ -2), `-1` resolves to `omp_get_max_threads()` so `OMP_NUM_THREADS`/affinity are respected.

**Determinism guarantee: with the same seed, all outputs are bit-identical regardless of the thread count** (verified for 1/2/8 threads on 10 scenarios covering merging, signals, capacity interventions, and stochastic grids).

## Verification

- `tests/test_cpp_mode.py`: **214 passed** (211 existing tests pass unmodified; 1 new `threads` regression test; 1 new test comparing mid-simulation `VEHICLES_RUNNING` contents and vehicle positions between Python and C++ modes; 1 test recovered by fixing a shadowed duplicate function name).
- Bit-identity harness (10 scenarios, sha256 over all vehicle logs, link travel times, cumulative curves, TTT): the 7 RNG-independent scenarios are bit-identical to current `main` through all commits; the 3 stochastic scenarios change only at the RNG-stream-separation commit and were validated by 30-seed statistical equivalence (Welch p > 0.05 on TTT/completed trips/mean speed; cross-engine link-volume correlation at within-engine level). The final structural-parity commit is bit-identical to the preceding state on all 10 scenarios at 1/2/8 threads.
- Python-validity check (Python 10 seeds vs C++ 30 seeds, 11x11 heavy grid + 8x8 signal grid): all indicators p = 0.11–0.86, mean differences ≤ 1.8%, cross correlation ≥ within correlation. PASS.

## Benchmarks

Measured on the heavy grid scenario (11x11, deltan=3, tmax=7200, full logging); single-threaded comparisons use interleaved A/B builds (5 rounds, medians of 10 reps).

vs Python engine (same scenario, exec median, same measurement session):

| Configuration | Speedup |
|---|---|
| C++ 1 thread | 28.2x |
| C++ 8 threads | **49.7x** |

vs current C++ engine on `main` (1 thread, interleaved A/B): **parity** — median-of-medians −1.4 to −1.7% (within measurement noise). The parallelization adds no single-thread cost.

Thread scaling (main_loop, logging on, medians):

| threads | main_loop | speedup |
|---|---|---|
| 1 | 1.410 s | 1.00x |
| 2 | 0.942 s | 1.50x |
| 4 | 0.682 s | 2.07x |
| 8 | 0.362 s | **3.90x** |

For reference, the SoA refactor in #340 measured 2.76–2.88x at 8 threads on the same machine, so the AoS version scales better (smaller serial fraction relative to the parallelizable work). `exec_simulation` scaling saturates around 1.8x at 8 threads because the serial Python-side post-processing (`_sync_from_cpp`) dominates, same as in #340.

## Compatibility notes

- `Vehicle::update()`, `Vehicle::car_follow_newell()`, and the `vehicles_living`/`vehicles_running` registries are preserved with their original semantics (see Summary); the main loop calls them from stage-partitioned passes instead of a single id-ordered scan.
- Root `CMakeLists.txt` gains an OpenMP dependency (scikit-build-core uses the root file; the one under `uxsim/trafficpp/` is updated for consistency).
- Known pre-existing failures of `tests/test_verification_straight_road.py --cpp` (3 tests, `list + ndarray` harness incompatibility) are unaffected.

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
