### PR TITLE
Support adjust_node_capacity in C++ mode and define threads on World for both modes

### DIFF
--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -4389,6 +4389,123 @@ def test_override_signal():
     assert list(cum1) == list(cum2)  # list() for compatibility with cpp mode, where cum_arrival is a numpy array
 
 
+@pytest.mark.flaky(reruns=10)
+def test_adjust_node_capacity():
+
+    # simulation world
+    W = World(cpp=True,
+        name="",
+        deltan=1,
+        tmax=1200,
+        print_mode=1, save_mode=1, show_mode=1,
+        adjust_node_capacity=True,
+        random_seed=None,
+    )
+
+    # scenario
+    #merge network with signal
+    W.addNode("orig1", 0, 0)
+    W.addNode("orig2", 0, 2)
+    W.addNode("dest1", 0, 3)
+    W.addNode("dest2", 2, 1)
+    merge = W.addNode("merge", 1, 1)
+    W.addLink("link1", "orig1", "merge", length=3000, free_flow_speed=20, jam_density=0.2)
+    W.addLink("link2", "orig2", "merge", length=3000, free_flow_speed=20, jam_density=0.2)
+    link3 = W.addLink("link3", "merge", "dest1", length=1000, free_flow_speed=20, jam_density=0.2)
+    link4 = W.addLink("link4", "merge", "dest2", length=1000, free_flow_speed=20, jam_density=0.2)
+    W.adddemand("orig1", "dest1", 0, 500, 0.6)
+    W.adddemand("orig2", "dest2", 0, 500, 0.6)
+
+
+    # execute simulation
+    W.exec_simulation()
+
+    # visualize
+    #W.analyzer.time_space_diagram_traj_links([["link1", "link3"], ["link2", "link4"]], figsize=(6,3))
+    W.analyzer.print_simple_stats()
+
+    assert eq_tol(merge.flow_capacity, 0.8)
+    assert eq_tol((link3.departure_count(800)-link3.departure_count(300))/500, 0.4)
+    assert eq_tol((link4.departure_count(800)-link4.departure_count(300))/500, 0.4)
+
+
+@pytest.mark.flaky(reruns=10)
+def test_adjust_node_capacity_major_minor_free_flow():
+    W = World(cpp=True,
+        name="",
+        deltan=1,
+        tmax=1200,
+        print_mode=1, save_mode=1, show_mode=1,
+        random_seed=None,
+        adjust_node_capacity=True,
+    )
+
+    # scenario
+    #merge network with signal
+    W.addNode("orig1", 0, 0)
+    W.addNode("orig2", 0, 2)
+    W.addNode("dest1", 0, 3)
+    W.addNode("dest2", 2, 1)
+    merge = W.addNode("merge", 1, 1)
+    link1 = W.addLink("link1", "orig1", "merge", length=3000, free_flow_speed=20, number_of_lanes=2, jam_density_per_lane=0.2)
+    link2 = W.addLink("link2", "orig2", "merge", length=3000, free_flow_speed=20)
+    link3 = W.addLink("link3", "merge", "dest1", length=1000, free_flow_speed=20, number_of_lanes=2, jam_density_per_lane=0.2)
+    link4 = W.addLink("link4", "merge", "dest2", length=1000, free_flow_speed=20)
+    W.adddemand("orig1", "dest1", 0, 500, 1)
+    W.adddemand("orig2", "dest2", 0, 500, 0.5)
+
+    #merge.adjust_node_capacity()
+
+    # execute simulation
+    W.exec_simulation()
+
+    # visualize
+    #W.analyzer.time_space_diagram_traj_links([["link1", "link3"], ["link2", "link4"]], figsize=(6,3))
+    W.analyzer.print_simple_stats()
+
+    assert eq_tol(merge.flow_capacity, 1.6)
+    assert eq_tol((link3.departure_count(600)-link3.departure_count(300))/300, 1)
+    assert eq_tol((link4.departure_count(600)-link4.departure_count(300))/300, 0.5)
+
+@pytest.mark.flaky(reruns=10)
+def test_adjust_node_capacity_major_minor_congested():
+    W = World(cpp=True,
+        name="",
+        deltan=1,
+        tmax=1200,
+        print_mode=1, save_mode=1, show_mode=1,
+        random_seed=None,
+        adjust_node_capacity=True,
+    )
+
+    # scenario
+    #merge network with signal
+    W.addNode("orig1", 0, 0)
+    W.addNode("orig2", 0, 2)
+    W.addNode("dest1", 0, 3)
+    W.addNode("dest2", 2, 1)
+    merge = W.addNode("merge", 1, 1)
+    link1 = W.addLink("link1", "orig1", "merge", length=3000, free_flow_speed=20, number_of_lanes=2, jam_density_per_lane=0.2)
+    link2 = W.addLink("link2", "orig2", "merge", length=3000, free_flow_speed=20)
+    link3 = W.addLink("link3", "merge", "dest1", length=1000, free_flow_speed=20, number_of_lanes=2, jam_density_per_lane=0.2)
+    link4 = W.addLink("link4", "merge", "dest2", length=1000, free_flow_speed=20)
+    W.adddemand("orig1", "dest1", 0, 500, 1.2)
+    W.adddemand("orig2", "dest2", 0, 500, 0.6)
+
+    #merge.adjust_node_capacity()
+
+    # execute simulation
+    W.exec_simulation()
+
+    # visualize
+    #W.analyzer.time_space_diagram_traj_links([["link1", "link3"], ["link2", "link4"]], figsize=(6,3))
+    W.analyzer.print_simple_stats()
+
+    assert eq_tol(merge.flow_capacity, 1.6)
+    assert eq_tol((link3.departure_count(600)-link3.departure_count(300))/300, 1.6*2/3)
+    assert eq_tol((link4.departure_count(600)-link4.departure_count(300))/300, 1.6*1/3)
+
+
 # ======================================================================
 # From test_wrapper_functions.py
 # ======================================================================

--- a/tests/test_cpp_mode.py
+++ b/tests/test_cpp_mode.py
@@ -8880,6 +8880,29 @@ def test_threads_parameter():
         with pytest.raises(ValueError):
             World(name="", tmax=100, print_mode=0, save_mode=0, show_mode=0, cpp=True, threads=bad)
 
+    # Python mode: `threads` is a defined-but-ignored argument. It must not raise
+    # (no validation, any value accepted) and must not affect the result.
+    def build_and_run_python(threads):
+        kwargs = dict(name="", deltan=5, tmax=1000, print_mode=0, save_mode=0, show_mode=0,
+                      random_seed=42, no_cyclic_routing=True, cpp=False)
+        if threads is not None:
+            kwargs["threads"] = threads
+        W = World(**kwargs)
+        W.addNode("orig", 0, 0)
+        W.addNode("mid", 1, 0)
+        W.addNode("dest", 2, 0)
+        W.addLink("l1", "orig", "mid", length=1000, free_flow_speed=20, jam_density=0.2)
+        W.addLink("l2", "mid", "dest", length=1000, free_flow_speed=20, jam_density=0.2)
+        W.adddemand("orig", "dest", 0, 500, 0.3)
+        W.exec_simulation()
+        W.analyzer.basic_analysis()
+        return W.analyzer.total_travel_time
+
+    ttt_default = build_and_run_python(None)
+    ttt_4 = build_and_run_python(4)
+    ttt_all = build_and_run_python(-1)
+    assert ttt_default == ttt_4 == ttt_all
+
 
 ## misc
 

--- a/uxsim/trafficpp/bindings.cpp
+++ b/uxsim/trafficpp/bindings.cpp
@@ -541,6 +541,7 @@ NB_MODULE(uxsim_cpp, m) {
         .def_rw("hard_deterministic_mode", &World::hard_deterministic_mode)
         .def_rw("route_choice_update_gradual", &World::route_choice_update_gradual)
         .def_rw("no_cyclic_routing", &World::no_cyclic_routing)
+        .def_rw("adjust_node_capacity", &World::adjust_node_capacity)
         .def_rw("instantaneous_TT_timestep_interval", &World::instantaneous_TT_timestep_interval)
         .def_rw("num_threads", &World::num_threads)
         .def_ro("route_dist", &World::route_dist)
@@ -734,6 +735,7 @@ NB_MODULE(uxsim_cpp, m) {
         .def("transfer", &Node::transfer)
         .def("signal_update", &Node::signal_update)
         .def("flow_capacity_update", &Node::flow_capacity_update)
+        .def("adjust_node_capacity", &Node::adjust_node_capacity)
         ;
 
     //

--- a/uxsim/trafficpp/traffi.cpp
+++ b/uxsim/trafficpp/traffi.cpp
@@ -206,6 +206,23 @@ void Node::signal_update(){
     signal_log.push_back(signal_phase);
 }
 
+/**
+ * @brief Automatically determine the flow capacity of this node from the capacities of connected links, matching Python's Node.adjust_node_capacity. Does not override an already-set flow_capacity.
+ */
+void Node::adjust_node_capacity(){
+    if (flow_capacity < 0.0 && !in_links.empty() && !out_links.empty()){
+        double capacity_in = in_links[0]->capacity;
+        for (auto l : in_links) capacity_in = std::max(capacity_in, l->capacity);
+        double capacity_out = out_links[0]->capacity;
+        for (auto l : out_links) capacity_out = std::max(capacity_out, l->capacity);
+        flow_capacity = (capacity_in + capacity_out) / 2.0;
+        flow_capacity_remain = flow_capacity * w->delta_t;
+        if (number_of_lanes <= 0){
+            number_of_lanes = (int)std::ceil(flow_capacity / 0.8); //the number of lanes is determined by assuming 0.8 veh/s capacity per lane
+        }
+    }
+}
+
 void Node::flow_capacity_update(){
     if (flow_capacity >= 0.0){
         if (flow_capacity_remain < w->delta_n * (number_of_lanes > 0 ? number_of_lanes : 1)){
@@ -1227,6 +1244,11 @@ void World::set_t_max(double new_t_max){
 
 void World::initialize_adj_matrix(){
     if (flag_initialized==false){
+        if (adjust_node_capacity){
+            for (auto nd : nodes){
+                nd->adjust_node_capacity();
+            }
+        }
         adj_mat.resize(node_id, vector<int>(node_id, 0));
         adj_mat_time.resize(node_id, vector<double>(node_id, 0.0));
         for (auto ln : links){

--- a/uxsim/trafficpp/traffi.h
+++ b/uxsim/trafficpp/traffi.h
@@ -103,6 +103,7 @@ struct Node {
     void transfer();
     void signal_update();
     void flow_capacity_update();
+    void adjust_node_capacity();
 };
 
 // -----------------------------------------------------------------------
@@ -316,6 +317,7 @@ struct World {
     bool hard_deterministic_mode;
     bool route_choice_update_gradual;
     bool no_cyclic_routing;
+    bool adjust_node_capacity = false;
     int instantaneous_TT_timestep_interval = 5;
     int num_threads = 1;   // OpenMP thread count for parallel regions; -1 = all cores
 

--- a/uxsim/uxsim.py
+++ b/uxsim/uxsim.py
@@ -1686,6 +1686,7 @@ class World:
                  reduce_memory_delete_vehicle_route_pref: bool=False,
                  hard_deterministic_mode: bool=False,
                  meta_data: dict={}, user_attribute=None, user_function=None,
+                 threads: int=1,
                  cpp: bool=False):
         """
         Create a World.
@@ -1751,6 +1752,8 @@ class World:
             >>> ... #define your scenario
             >>> W.exec_simulation()
 
+        threads : int, optional
+            Number of threads for the C++ simulation engine (cpp=True). Default is 1 (single-threaded). N>=1 uses N threads; -1 uses all available cores. This argument is ignored in the Python mode (cpp=False).
         cpp : bool, optional
             Use C++ super-fast simulation mode. 
         

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -798,14 +798,7 @@ class CppRouteChoice:
 
 
 class CppWorld:
-    """Thin wrapper around C++ World. Delegates simulation to C++ engine.
-
-    C++-mode-only argument:
-        threads (int): number of OpenMP threads for the C++ engine. 1 (default)
-            runs single-threaded (the legacy behaviour); N>=1 uses N threads;
-            -1 uses all available cores (honouring OMP_NUM_THREADS and affinity
-            limits). This argument does not exist on the Python-mode World.
-    """
+    """Thin wrapper around C++ World. Delegates simulation to C++ engine."""
 
     def __init__(self, name="", deltan=5, reaction_time=1,
                  duo_update_time=600, duo_update_weight=0.5, duo_noise=0.01,

--- a/uxsim/uxsim_cpp_wrapper.py
+++ b/uxsim/uxsim_cpp_wrapper.py
@@ -169,6 +169,17 @@ class CppNode:
             key.signal_group = phase_info[key]
             key._cpp_link.signal_group = phase_info[key]
 
+    def adjust_node_capacity(self):
+        """
+        Automatically determine the `flow_capacity` of this node based on the capacity of connected links. It does not override if `flow_capacity` was already set.
+        This calculation is based on an assumption that the node is an intersection with two major roads and two minor roads or similar types. In this case, the node capacity should be the same to that of major roads.
+        """
+        self._cpp_node.adjust_node_capacity()
+        if self._cpp_node.number_of_lanes != self.number_of_lanes:
+            self.flag_lanes_automatically_determined = True
+        self.flow_capacity = self._cpp_node.flow_capacity
+        self.number_of_lanes = self._cpp_node.number_of_lanes
+
 
 class CppLink:
     """Thin wrapper around C++ Link. Stores attributes for analyzer compatibility."""
@@ -808,6 +819,7 @@ class CppWorld:
                  reduce_memory_delete_vehicle_route_pref=False,
                  hard_deterministic_mode=False,
                  no_cyclic_routing=False,
+                 adjust_node_capacity=False,
                  meta_data=None, user_attribute=None, user_function=None,
                  threads=1):
 
@@ -843,6 +855,7 @@ class CppWorld:
         self.name = name
         self.hard_deterministic_mode = hard_deterministic_mode
         self.no_cyclic_routing = no_cyclic_routing
+        self.adjust_node_capacity = adjust_node_capacity
         if not isinstance(threads, int) or isinstance(threads, bool) or (threads < 1 and threads != -1):
             raise ValueError(f"threads must be a positive integer or -1 (all cores), got {threads!r}.")
         self.num_threads = threads
@@ -887,6 +900,7 @@ class CppWorld:
         self._cpp_world_created = True
         self._cpp_world.route_choice_update_gradual = self.route_choice_update_gradual
         self._cpp_world.no_cyclic_routing = self.no_cyclic_routing
+        self._cpp_world.adjust_node_capacity = bool(self.adjust_node_capacity)
         self._cpp_world.instantaneous_TT_timestep_interval = int(self.instantaneous_TT_timestep_interval)
         self._cpp_world.num_threads = int(self.num_threads)
 
@@ -1090,6 +1104,12 @@ class CppWorld:
         self._cpp_world.show_progress = int(self.show_progress)
         self._cpp_world.show_progress_deltat_timestep = max(int(self.show_progress_deltat_timestep), 0)
         self._cpp_world.initialize_adj_matrix()
+
+        # Adjust node capacities (done in C++ by initialize_adj_matrix; here we sync the wrapper-side attributes)
+        if self.adjust_node_capacity:
+            for node in self.NODES:
+                node.adjust_node_capacity()
+
         self._setup_analyzer()
 
         # Pre-compute congestion pricing tolls and pass to C++ as timeseries


### PR DESCRIPTION
## Summary

Two follow-up changes for the C++ mode:

1. **`adjust_node_capacity` support in C++ mode** — ports the feature added for the Python mode in #344 to the C++ engine, so `World(cpp=True, adjust_node_capacity=True)` behaves the same as the Python mode.
2. **`threads` defined on `World` for both modes** — the `threads` argument introduced in #341 was a cpp-mode-only extension of the wrapper, so `World(cpp=False, threads=N)` raised `TypeError`. It is now a regular `World.__init__` parameter documented in `uxsim.py`; the Python mode accepts and simply ignores it.

## Details

### adjust_node_capacity (commit 1)

- `Node::adjust_node_capacity()` in the C++ engine mirrors the Python implementation line by line: if `flow_capacity` is unset (C++ sentinel `-1.0` corresponding to Python `None`) and the node has both in- and out-links, it sets `flow_capacity = (max(inlink capacities) + max(outlink capacities)) / 2`, updates `flow_capacity_remain = flow_capacity * DELTAT`, and derives `number_of_lanes = ceil(flow_capacity / 0.8)` when lanes are unset (flagging `flag_lanes_automatically_determined`).
- Applied to all nodes at scenario finalization (`initialize_adj_matrix`), the same timing as the Python mode's `finalize_scenario`. Idempotent once `flow_capacity >= 0`.
- The wrapper exposes `CppNode.adjust_node_capacity()` and syncs the wrapper-side node attributes after finalization.
- Validation: on a 6x6 grid mixing 2-lane major and 1-lane minor roads (8000 vehicles, 5 seeds), the resulting `flow_capacity` and `number_of_lanes` of every node are identical between Python and C++ modes; TTT differs by +0.89% on average (expected RNG-sequence effect).

### threads on World (commit 2)

- `threads: int=1` is inserted in `World.__init__` immediately before `cpp`, matching the positional layout of the wrapper's `CppWorld.__init__`, with a numpydoc entry (default 1; N≥1 threads; -1 = all cores; ignored when `cpp=False`).
- The Python mode performs no validation and stores nothing — the argument simply has no effect there. The C++ mode keeps the existing validation (bool rejected, `ValueError` for 0 / ≤ -2) and forwarding to the engine.

## Tests

- `tests/test_cpp_mode.py`: **217 passed** — three `adjust_node_capacity` tests ported from `tests/test_verification_node.py` (merge capacity, major/minor free-flow, major/minor congested), and `test_threads_parameter` extended with a Python-mode block asserting `World(cpp=False)` with `threads=4` / `threads=-1` runs and produces results identical to omitting the argument.
- `tests/test_other_functions.py`: 28 passed (1 pre-existing environment-only failure: `osmnx` not installed).

Part of https://github.com/toruseo/UXsim/issues/297

🤖 Generated with [Claude Code](https://claude.com/claude-code)
